### PR TITLE
fix: enable stdin for Fabric runServer task

### DIFF
--- a/26.1-fabric/build.gradle.kts
+++ b/26.1-fabric/build.gradle.kts
@@ -149,3 +149,7 @@ loom {
         ideConfigGenerated(true)
     }
 }
+
+tasks.withType<JavaExec> {
+    standardInput = System.`in`
+}


### PR DESCRIPTION
Add standardInput = System.in to all JavaExec tasks in the Fabric
subproject, matching the existing configuration in NeoForge and Forge
subprojects.

https://claude.ai/code/session_01ES8FhZsMcLpCqwNwQ963xh