### PR TITLE
ci: forge/neoforgeでrunGameTestServerを実行

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
       - name: Build with Gradle
         run: chmod u+x ./gradlew && ./gradlew ":${{ matrix.submodule }}:build"
 
+      - name: Run Game Tests
+        if: "!contains(matrix.submodule, 'fabric')"
+        run: ./gradlew ":${{ matrix.submodule }}:runGameTestServer"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
fabricはbuild時に自動実行されるため対象外。
サブモジュール名に'fabric'が含まれない場合のみRun Game Testsステップを実行する。