### PR TITLE
refactor: ビルドスクリプトの共通設定をルートのsubprojectsに集約

### DIFF
--- a/1.18.2-forge/build.gradle.kts
+++ b/1.18.2-forge/build.gradle.kts
@@ -49,15 +49,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-tasks.withType<JavaCompile>().configureEach {
-    doFirst {
-        with(javaCompiler.get().metadata) {
-            println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
-        }
-    }
-    options.encoding = "UTF-8"
-}
-
 legacyForge {
     version = forgeFullVersion
 

--- a/1.18.2-forge/build.gradle.kts
+++ b/1.18.2-forge/build.gradle.kts
@@ -129,13 +129,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 legacyForge.ideSyncTask(generateModMetadata)
 
-idea {
-    module {
-        isDownloadSources = true
-        isDownloadJavadoc = true
-    }
-}
-
 tasks.withType<JavaExec> {
     standardInput = System.`in`
 }

--- a/1.18.2-forge/build.gradle.kts
+++ b/1.18.2-forge/build.gradle.kts
@@ -20,57 +20,17 @@ val modId: String by project
 val modName: String by project
 val modLicense: String by project
 val modVersion: String by project
-val modGroupId: String by project
 val modAuthors: String by project
 val modDescription: String by project
 val modDisplayUrl: String by project
 val modIssueTrackerUrl: String by project
 val modCredits: String by project
 
-repositories {
-//    flatDir {
-//        dir("libs")
-//    }
-
-//    maven {
-//        name = "ModMaven"
-//        url = uri("https://modmaven.dev/")
-//    }
-
-//    exclusiveContent {
-//        forRepository {
-//            maven {
-//                name = "Modrinth"
-//                url = uri("https://api.modrinth.com/maven")
-//            }
-//        }
-//        filter {
-//            includeGroup("maven.modrinth")
-//        }
-//    }
-
-    exclusiveContent {
-        forRepository {
-            maven {
-                url = uri("https://cursemaven.com")
-            }
-        }
-        filter {
-            includeGroup("curse.maven")
-        }
-    }
-}
-
 dependencies {
     // Default Dependencies
 
     // Mod Dependencies
 }
-
-/// Project Settings ///
-
-version = "v$modVersion"
-group = modGroupId
 
 sourceSets.main.get().resources {
     srcDir("src/generated/resources")

--- a/1.18.2-forge/build.gradle.kts
+++ b/1.18.2-forge/build.gradle.kts
@@ -49,14 +49,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-with(System.getProperties()) {
-    val version = get("java.version")
-    val vmVersion = get("java.vm.version")
-    val vendor = get("java.vendor")
-    val arch = get("os.arch")
-    println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
-}
-
 tasks.withType<JavaCompile>().configureEach {
     doFirst {
         with(javaCompiler.get().metadata) {

--- a/1.18.2-forge/build.gradle.kts
+++ b/1.18.2-forge/build.gradle.kts
@@ -128,7 +128,3 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 legacyForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaExec> {
-    standardInput = System.`in`
-}

--- a/1.18.2-forge/build.gradle.kts
+++ b/1.18.2-forge/build.gradle.kts
@@ -103,6 +103,7 @@ tasks.withType<JavaCompile>().configureEach {
             println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
         }
     }
+    options.encoding = "UTF-8"
 }
 
 legacyForge {
@@ -184,10 +185,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 legacyForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaCompile>().configureEach {
-    options.encoding = "UTF-8"
-}
 
 idea {
     module {

--- a/1.19.2-forge/build.gradle.kts
+++ b/1.19.2-forge/build.gradle.kts
@@ -49,15 +49,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-tasks.withType<JavaCompile>().configureEach {
-    doFirst {
-        with(javaCompiler.get().metadata) {
-            println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
-        }
-    }
-    options.encoding = "UTF-8"
-}
-
 legacyForge {
     version = forgeFullVersion
 

--- a/1.19.2-forge/build.gradle.kts
+++ b/1.19.2-forge/build.gradle.kts
@@ -129,13 +129,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 legacyForge.ideSyncTask(generateModMetadata)
 
-idea {
-    module {
-        isDownloadSources = true
-        isDownloadJavadoc = true
-    }
-}
-
 tasks.withType<JavaExec> {
     standardInput = System.`in`
 }

--- a/1.19.2-forge/build.gradle.kts
+++ b/1.19.2-forge/build.gradle.kts
@@ -20,57 +20,17 @@ val modId: String by project
 val modName: String by project
 val modLicense: String by project
 val modVersion: String by project
-val modGroupId: String by project
 val modAuthors: String by project
 val modDescription: String by project
 val modDisplayUrl: String by project
 val modIssueTrackerUrl: String by project
 val modCredits: String by project
 
-repositories {
-//    flatDir {
-//        dir("libs")
-//    }
-
-//    maven {
-//        name = "ModMaven"
-//        url = uri("https://modmaven.dev/")
-//    }
-
-//    exclusiveContent {
-//        forRepository {
-//            maven {
-//                name = "Modrinth"
-//                url = uri("https://api.modrinth.com/maven")
-//            }
-//        }
-//        filter {
-//            includeGroup("maven.modrinth")
-//        }
-//    }
-
-    exclusiveContent {
-        forRepository {
-            maven {
-                url = uri("https://cursemaven.com")
-            }
-        }
-        filter {
-            includeGroup("curse.maven")
-        }
-    }
-}
-
 dependencies {
     // Default Dependencies
 
     // Mod Dependencies
 }
-
-/// Project Settings ///
-
-version = "v$modVersion"
-group = modGroupId
 
 sourceSets.main.get().resources {
     srcDir("src/generated/resources")

--- a/1.19.2-forge/build.gradle.kts
+++ b/1.19.2-forge/build.gradle.kts
@@ -49,14 +49,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-with(System.getProperties()) {
-    val version = get("java.version")
-    val vmVersion = get("java.vm.version")
-    val vendor = get("java.vendor")
-    val arch = get("os.arch")
-    println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
-}
-
 tasks.withType<JavaCompile>().configureEach {
     doFirst {
         with(javaCompiler.get().metadata) {

--- a/1.19.2-forge/build.gradle.kts
+++ b/1.19.2-forge/build.gradle.kts
@@ -128,7 +128,3 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 legacyForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaExec> {
-    standardInput = System.`in`
-}

--- a/1.19.2-forge/build.gradle.kts
+++ b/1.19.2-forge/build.gradle.kts
@@ -103,6 +103,7 @@ tasks.withType<JavaCompile>().configureEach {
             println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
         }
     }
+    options.encoding = "UTF-8"
 }
 
 legacyForge {
@@ -184,10 +185,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 legacyForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaCompile>().configureEach {
-    options.encoding = "UTF-8"
-}
 
 idea {
     module {

--- a/1.20.1-forge/build.gradle.kts
+++ b/1.20.1-forge/build.gradle.kts
@@ -49,15 +49,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-tasks.withType<JavaCompile>().configureEach {
-    doFirst {
-        with(javaCompiler.get().metadata) {
-            println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
-        }
-    }
-    options.encoding = "UTF-8"
-}
-
 legacyForge {
     version = forgeFullVersion
 

--- a/1.20.1-forge/build.gradle.kts
+++ b/1.20.1-forge/build.gradle.kts
@@ -129,13 +129,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 legacyForge.ideSyncTask(generateModMetadata)
 
-idea {
-    module {
-        isDownloadSources = true
-        isDownloadJavadoc = true
-    }
-}
-
 tasks.withType<JavaExec> {
     standardInput = System.`in`
 }

--- a/1.20.1-forge/build.gradle.kts
+++ b/1.20.1-forge/build.gradle.kts
@@ -20,57 +20,17 @@ val modId: String by project
 val modName: String by project
 val modLicense: String by project
 val modVersion: String by project
-val modGroupId: String by project
 val modAuthors: String by project
 val modDescription: String by project
 val modDisplayUrl: String by project
 val modIssueTrackerUrl: String by project
 val modCredits: String by project
 
-repositories {
-//    flatDir {
-//        dir("libs")
-//    }
-
-//    maven {
-//        name = "ModMaven"
-//        url = uri("https://modmaven.dev/")
-//    }
-
-//    exclusiveContent {
-//        forRepository {
-//            maven {
-//                name = "Modrinth"
-//                url = uri("https://api.modrinth.com/maven")
-//            }
-//        }
-//        filter {
-//            includeGroup("maven.modrinth")
-//        }
-//    }
-
-    exclusiveContent {
-        forRepository {
-            maven {
-                url = uri("https://cursemaven.com")
-            }
-        }
-        filter {
-            includeGroup("curse.maven")
-        }
-    }
-}
-
 dependencies {
     // Default Dependencies
 
     // Mod Dependencies
 }
-
-/// Project Settings ///
-
-version = "v$modVersion"
-group = modGroupId
 
 sourceSets.main.get().resources {
     srcDir("src/generated/resources")

--- a/1.20.1-forge/build.gradle.kts
+++ b/1.20.1-forge/build.gradle.kts
@@ -49,14 +49,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-with(System.getProperties()) {
-    val version = get("java.version")
-    val vmVersion = get("java.vm.version")
-    val vendor = get("java.vendor")
-    val arch = get("os.arch")
-    println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
-}
-
 tasks.withType<JavaCompile>().configureEach {
     doFirst {
         with(javaCompiler.get().metadata) {

--- a/1.20.1-forge/build.gradle.kts
+++ b/1.20.1-forge/build.gradle.kts
@@ -128,7 +128,3 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 legacyForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaExec> {
-    standardInput = System.`in`
-}

--- a/1.20.1-forge/build.gradle.kts
+++ b/1.20.1-forge/build.gradle.kts
@@ -103,6 +103,7 @@ tasks.withType<JavaCompile>().configureEach {
             println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
         }
     }
+    options.encoding = "UTF-8"
 }
 
 legacyForge {
@@ -184,10 +185,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 legacyForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaCompile>().configureEach {
-    options.encoding = "UTF-8"
-}
 
 idea {
     module {

--- a/1.21.1-neo/build.gradle.kts
+++ b/1.21.1-neo/build.gradle.kts
@@ -18,57 +18,17 @@ val modId: String by project
 val modName: String by project
 val modLicense: String by project
 val modVersion: String by project
-val modGroupId: String by project
 val modAuthors: String by project
 val modDescription: String by project
 val modDisplayUrl: String by project
 val modIssueTrackerUrl: String by project
 val modCredits: String by project
 
-repositories {
-//    flatDir {
-//        dir("libs")
-//    }
-
-//    maven {
-//        name = "ModMaven"
-//        url = uri("https://modmaven.dev/")
-//    }
-
-//    exclusiveContent {
-//        forRepository {
-//            maven {
-//                name = "Modrinth"
-//                url = uri("https://api.modrinth.com/maven")
-//            }
-//        }
-//        filter {
-//            includeGroup("maven.modrinth")
-//        }
-//    }
-
-    exclusiveContent {
-        forRepository {
-            maven {
-                url = uri("https://cursemaven.com")
-            }
-        }
-        filter {
-            includeGroup("curse.maven")
-        }
-    }
-}
-
 dependencies {
     // Default Dependencies
 
     // Mod Dependencies
 }
-
-/// Project Settings ///
-
-version = "v$modVersion"
-group = modGroupId
 
 sourceSets.main.get().resources {
     srcDir("src/generated/resources")

--- a/1.21.1-neo/build.gradle.kts
+++ b/1.21.1-neo/build.gradle.kts
@@ -101,6 +101,7 @@ tasks.withType<JavaCompile>().configureEach {
             println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
         }
     }
+    options.encoding = "UTF-8"
 }
 
 neoForge {
@@ -181,10 +182,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 neoForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaCompile>().configureEach {
-    options.encoding = "UTF-8"
-}
 
 idea {
     module {

--- a/1.21.1-neo/build.gradle.kts
+++ b/1.21.1-neo/build.gradle.kts
@@ -126,13 +126,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 neoForge.ideSyncTask(generateModMetadata)
 
-idea {
-    module {
-        isDownloadSources = true
-        isDownloadJavadoc = true
-    }
-}
-
 tasks.withType<JavaExec> {
     standardInput = System.`in`
 }

--- a/1.21.1-neo/build.gradle.kts
+++ b/1.21.1-neo/build.gradle.kts
@@ -47,15 +47,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-tasks.withType<JavaCompile>().configureEach {
-    doFirst {
-        with(javaCompiler.get().metadata) {
-            println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
-        }
-    }
-    options.encoding = "UTF-8"
-}
-
 neoForge {
     version = neoVersion
 

--- a/1.21.1-neo/build.gradle.kts
+++ b/1.21.1-neo/build.gradle.kts
@@ -125,7 +125,3 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 neoForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaExec> {
-    standardInput = System.`in`
-}

--- a/1.21.1-neo/build.gradle.kts
+++ b/1.21.1-neo/build.gradle.kts
@@ -47,14 +47,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-with(System.getProperties()) {
-    val version = get("java.version")
-    val vmVersion = get("java.vm.version")
-    val vendor = get("java.vendor")
-    val arch = get("os.arch")
-    println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
-}
-
 tasks.withType<JavaCompile>().configureEach {
     doFirst {
         with(javaCompiler.get().metadata) {

--- a/26.1-fabric/build.gradle.kts
+++ b/26.1-fabric/build.gradle.kts
@@ -59,13 +59,7 @@ java.toolchain {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    doFirst {
-        with(javaCompiler.get().metadata) {
-            println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
-        }
-    }
     options.release = 25
-    options.encoding = "UTF-8"
 }
 
 java {

--- a/26.1-fabric/build.gradle.kts
+++ b/26.1-fabric/build.gradle.kts
@@ -122,7 +122,3 @@ fabricApi {
         eula = true
     }
 }
-
-tasks.withType<JavaExec> {
-    standardInput = System.`in`
-}

--- a/26.1-fabric/build.gradle.kts
+++ b/26.1-fabric/build.gradle.kts
@@ -17,7 +17,6 @@ val modId: String by project
 val modName: String by project
 val modLicense: String by project
 val modVersion: String by project
-val modGroupId: String by project
 val modAuthors: String by project
 val modDescription: String by project
 val modDisplayUrl: String by project
@@ -26,8 +25,6 @@ val modCredits: String by project
 val modFabricEntrypoint: String by project
 val modFabricClientEntrypoint: String by project
 
-version = "v$modVersion"
-group = modGroupId
 val resolvedVersion = version.toString()
 val resolvedProjectName = project.name
 val generatedModMetadataDir = layout.buildDirectory.dir("generated/sources/modMetadata")
@@ -37,19 +34,6 @@ base {
 }
 
 sourceSets.main.get().resources.srcDir(generatedModMetadataDir)
-
-repositories {
-    exclusiveContent {
-        forRepository {
-            maven {
-                url = uri("https://cursemaven.com")
-            }
-        }
-        filter {
-            includeGroup("curse.maven")
-        }
-    }
-}
 
 loom {
     splitEnvironmentSourceSets()

--- a/26.1-fabric/build.gradle.kts
+++ b/26.1-fabric/build.gradle.kts
@@ -58,14 +58,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-with(System.getProperties()) {
-    val version = get("java.version")
-    val vmVersion = get("java.vm.version")
-    val vendor = get("java.vendor")
-    val arch = get("os.arch")
-    println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
-}
-
 tasks.withType<JavaCompile>().configureEach {
     doFirst {
         with(javaCompiler.get().metadata) {

--- a/26.1-fabric/build.gradle.kts
+++ b/26.1-fabric/build.gradle.kts
@@ -107,13 +107,6 @@ tasks.named("sourcesJar") {
 //     }
 // }
 
-idea {
-    module {
-        isDownloadSources = true
-        isDownloadJavadoc = true
-    }
-}
-
 loom {
     runs.configureEach {
         ideConfigGenerated(true)

--- a/26.1-neo/build.gradle.kts
+++ b/26.1-neo/build.gradle.kts
@@ -98,6 +98,7 @@ tasks.withType<JavaCompile>().configureEach {
             println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
         }
     }
+    options.encoding = "UTF-8"
 }
 
 neoForge {
@@ -172,10 +173,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 neoForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaCompile>().configureEach {
-    options.encoding = "UTF-8"
-}
 
 idea {
     module {

--- a/26.1-neo/build.gradle.kts
+++ b/26.1-neo/build.gradle.kts
@@ -117,13 +117,6 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 neoForge.ideSyncTask(generateModMetadata)
 
-idea {
-    module {
-        isDownloadSources = true
-        isDownloadJavadoc = true
-    }
-}
-
 tasks.withType<JavaExec> {
     standardInput = System.`in`
 }

--- a/26.1-neo/build.gradle.kts
+++ b/26.1-neo/build.gradle.kts
@@ -15,57 +15,17 @@ val modId: String by project
 val modName: String by project
 val modLicense: String by project
 val modVersion: String by project
-val modGroupId: String by project
 val modAuthors: String by project
 val modDescription: String by project
 val modDisplayUrl: String by project
 val modIssueTrackerUrl: String by project
 val modCredits: String by project
 
-repositories {
-//    flatDir {
-//        dir("libs")
-//    }
-
-//    maven {
-//        name = "ModMaven"
-//        url = uri("https://modmaven.dev/")
-//    }
-
-//    exclusiveContent {
-//        forRepository {
-//            maven {
-//                name = "Modrinth"
-//                url = uri("https://api.modrinth.com/maven")
-//            }
-//        }
-//        filter {
-//            includeGroup("maven.modrinth")
-//        }
-//    }
-
-    exclusiveContent {
-        forRepository {
-            maven {
-                url = uri("https://cursemaven.com")
-            }
-        }
-        filter {
-            includeGroup("curse.maven")
-        }
-    }
-}
-
 dependencies {
     // Default Dependencies
 
     // Mod Dependencies
 }
-
-/// Project Settings ///
-
-version = "v$modVersion"
-group = modGroupId
 
 sourceSets.main.get().resources {
     srcDir("src/generated/resources")

--- a/26.1-neo/build.gradle.kts
+++ b/26.1-neo/build.gradle.kts
@@ -44,15 +44,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-tasks.withType<JavaCompile>().configureEach {
-    doFirst {
-        with(javaCompiler.get().metadata) {
-            println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
-        }
-    }
-    options.encoding = "UTF-8"
-}
-
 neoForge {
     version = neoVersion
 

--- a/26.1-neo/build.gradle.kts
+++ b/26.1-neo/build.gradle.kts
@@ -116,7 +116,3 @@ val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata"
 
 sourceSets.main.get().resources.srcDir(generateModMetadata)
 neoForge.ideSyncTask(generateModMetadata)
-
-tasks.withType<JavaExec> {
-    standardInput = System.`in`
-}

--- a/26.1-neo/build.gradle.kts
+++ b/26.1-neo/build.gradle.kts
@@ -44,14 +44,6 @@ java.toolchain {
     vendor = JvmVendorSpec.JETBRAINS
 }
 
-with(System.getProperties()) {
-    val version = get("java.version")
-    val vmVersion = get("java.vm.version")
-    val vendor = get("java.vendor")
-    val arch = get("os.arch")
-    println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
-}
-
 tasks.withType<JavaCompile>().configureEach {
     doFirst {
         with(javaCompiler.get().metadata) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,4 +35,13 @@ subprojects {
         val arch = get("os.arch")
         println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
     }
+
+    tasks.withType<JavaCompile>().configureEach {
+        doFirst {
+            with(javaCompiler.get().metadata) {
+                println("Compiling with Java: $javaRuntimeVersion, JVM: $jvmVersion ($vendor)")
+            }
+        }
+        options.encoding = "UTF-8"
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,4 +44,13 @@ subprojects {
         }
         options.encoding = "UTF-8"
     }
+
+    plugins.withId("idea") {
+        configure<org.gradle.plugins.ide.idea.model.IdeaModel> {
+            module {
+                isDownloadSources = true
+                isDownloadJavadoc = true
+            }
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,3 +7,24 @@ plugins {
 tasks.named<Wrapper>("wrapper").configure {
     distributionType = Wrapper.DistributionType.BIN
 }
+
+subprojects {
+    val modVersion: String by project
+    val modGroupId: String by project
+
+    version = "v$modVersion"
+    group = modGroupId
+
+    repositories {
+//        flatDir { dir("libs") }
+//        maven { name = "ModMaven"; url = uri("https://modmaven.dev/") }
+//        exclusiveContent {
+//            forRepository { maven { name = "Modrinth"; url = uri("https://api.modrinth.com/maven") } }
+//            filter { includeGroup("maven.modrinth") }
+//        }
+        exclusiveContent {
+            forRepository { maven { url = uri("https://cursemaven.com") } }
+            filter { includeGroup("curse.maven") }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,4 +27,12 @@ subprojects {
             filter { includeGroup("curse.maven") }
         }
     }
+
+    with(System.getProperties()) {
+        val version = get("java.version")
+        val vmVersion = get("java.vm.version")
+        val vendor = get("java.vendor")
+        val arch = get("os.arch")
+        println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,12 @@ subprojects {
         options.encoding = "UTF-8"
     }
 
+    afterEvaluate {
+        tasks.withType<JavaExec>().configureEach {
+            standardInput = System.`in`
+        }
+    }
+
     plugins.withId("idea") {
         configure<org.gradle.plugins.ide.idea.model.IdeaModel> {
             module {


### PR DESCRIPTION
## Summary

各サブプロジェクトで重複していたビルドスクリプトの設定を、ルートの `subprojects {}` ブロックに段階的に共通化しました。

- `version` / `group` の設定および `repositories {}` を共通化
- `with(System.getProperties())` のログ出力を共通化
- `tasks.withType<JavaCompile>` (doFirst ログ + encoding) を共通化（fabric は固有の `options.release = 25` のみ残存）
- `idea { module {} }` を共通化（`plugins.withId("idea")` で遅延実行しタイミング問題を回避）
- `tasks.withType<JavaExec> { standardInput }` を共通化（`afterEvaluate` で遅延実行し fabric-loom の NPE を回避）

## Test plan

- [x] `./gradlew help` でビルド設定が全サブプロジェクト正常にロードされることを確認
- [x] 各サブプロジェクトのビルドが引き続き通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)