### PR TITLE
docs: add commit message convention to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,14 @@ type(scope): description
 
 Subprojects are the top-level directories corresponding to each platform/version (such as `26.1-fabric` or `1.20.1-forge`).
 
-| Changes affect...                | Scope                                                                  |
-|----------------------------------|------------------------------------------------------------------------|
-| A single subproject              | Use that subproject's directory name (e.g. `fix(26.1-fabric): ...`)    |
-| Multiple but not all subprojects | Include the relevant names (e.g. `feat(1.20.1-forge,1.21.1-neo): ...`) |
-| All subprojects equally          | Scope is optional                                                      |
-| Root-level files only            | Scope is optional                                                      |
+| Changes affect...                            | Scope                                                                  |
+|----------------------------------------------|------------------------------------------------------------------------|
+| A single subproject                          | Use that subproject's directory name (e.g. `fix(26.1-fabric): ...`)    |
+| Multiple but not all subprojects             | Include the relevant names (e.g. `feat(1.20.1-forge,1.21.1-neo): ...`) |
+| All loaders for a specific Minecraft version | Use only the version number (e.g. `fix(1.20.1): ...`)                  |
+| All Minecraft versions for a specific loader | Use only the loader name (e.g. `feat(fabric): ...`)                    |
+| All subprojects equally                      | Scope is optional                                                      |
+| Root-level files only                        | Scope is optional                                                      |
 
 ### Valid types
 
@@ -30,4 +32,6 @@ feat(26.1-fabric): add config screen
 fix(1.20.1-forge): resolve crash on startup
 build: upgrade Gradle to 8.14
 chore(1.18.2-forge,1.19.2-forge): bump forge version
+fix(1.20.1): resolve crash affecting all 1.20.1 loaders
+feat(fabric): add Fabric API integration across all versions
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,16 +12,16 @@ type(scope): description
 
 Subprojects are the top-level directories corresponding to each platform/version (such as `26.1-fabric` or `1.20.1-forge`).
 
-| Changes affect... | Scope |
-|---|---|
-| A single subproject | Use that subproject's directory name (e.g. `fix(26.1-fabric): ...`) |
+| Changes affect...                | Scope                                                                  |
+|----------------------------------|------------------------------------------------------------------------|
+| A single subproject              | Use that subproject's directory name (e.g. `fix(26.1-fabric): ...`)    |
 | Multiple but not all subprojects | Include the relevant names (e.g. `feat(1.20.1-forge,1.21.1-neo): ...`) |
-| All subprojects equally | Scope is optional |
-| Root-level files only | Scope is optional |
+| All subprojects equally          | Scope is optional                                                      |
+| Root-level files only            | Scope is optional                                                      |
 
 ### Valid types
 
-`feat` · `fix` · `docs` · `style` · `refactor` · `perf` · `test` · `build` · `ci` · `chore` · `revert`
+`feat` / `fix` / `docs` / `style` / `refactor` / `perf` / `test` / `build` / `ci` / `chore` / `revert`
 
 ### Examples
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+## Commit Message Convention
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): description
+```
+
+### Scope rules for subprojects
+
+Subprojects are the top-level directories corresponding to each platform/version (such as `26.1-fabric` or `1.20.1-forge`).
+
+| Changes affect... | Scope |
+|---|---|
+| A single subproject | Use that subproject's directory name (e.g. `fix(26.1-fabric): ...`) |
+| Multiple but not all subprojects | Include the relevant names (e.g. `feat(1.20.1-forge,1.21.1-neo): ...`) |
+| All subprojects equally | Scope is optional |
+| Root-level files only | Scope is optional |
+
+### Valid types
+
+`feat` · `fix` · `docs` · `style` · `refactor` · `perf` · `test` · `build` · `ci` · `chore` · `revert`
+
+### Examples
+
+```
+feat(26.1-fabric): add config screen
+fix(1.20.1-forge): resolve crash on startup
+build: upgrade Gradle to 8.14
+chore(1.18.2-forge,1.19.2-forge): bump forge version
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,9 @@ Subprojects are the top-level directories corresponding to each platform/version
 | All subprojects equally                      | Scope is optional                                                      |
 | Root-level files only                        | Scope is optional                                                      |
 
-### Valid types
+### Recommended types
 
-`feat` / `fix` / `docs` / `style` / `refactor` / `perf` / `test` / `build` / `ci` / `chore` / `revert`
+`feat` / `fix` / `docs` / `style` / `refactor` / `perf` / `test` / `build` / `ci` / `chore` / `revert` / `release`
 
 ### Examples
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Commit Message Convention
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+Should follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
 type(scope): description


### PR DESCRIPTION
## Summary

- Conventional Commits に従ったコミットメッセージ規約を `CONTRIBUTING.md` に追加
- サブプロジェクト (`26.1-fabric`, `1.20.1-forge` 等) への変更は、全サブプロジェクトに影響しない限りスコープを明示する旨を記載
- 強制ではなくガイドラインとして、エージェント・人間の両方を対象

https://claude.ai/code/session_01JyC9NjfdY9V1rL18ZJG8o2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyC9NjfdY9V1rL18ZJG8o2)_