### PR TITLE
docs: READMEをdocs/READMEへ移動

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,4 +55,4 @@ Build a specific platform:
 
 ## License
 
-[MIT](LICENSE)
+[MIT](../LICENSE)


### PR DESCRIPTION
フォーク先のリポジトリでREADMEが競合しないようにするため