### PR TITLE
Add common subproject and move MODID declaration to Constants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         run: chmod u+x ./gradlew && ./gradlew ":${{ matrix.submodule }}:build"
 
       - name: Run Game Tests
-        if: "!contains(matrix.submodule, 'fabric')"
+        if: "endsWith(matrix.submodule, 'neo') || endsWith(matrix.submodule, 'forge')"
         run: ./gradlew ":${{ matrix.submodule }}:runGameTestServer"
 
       - name: Upload artifact

--- a/1.18.2-forge/build.gradle.kts
+++ b/1.18.2-forge/build.gradle.kts
@@ -28,6 +28,7 @@ val modCredits: String by project
 
 dependencies {
     // Default Dependencies
+    implementation(project(":common"))
 
     // Mod Dependencies
 }

--- a/1.18.2-forge/src/main/java/net/meatwo310/examplemod/ExampleMod.java
+++ b/1.18.2-forge/src/main/java/net/meatwo310/examplemod/ExampleMod.java
@@ -3,15 +3,13 @@ package net.meatwo310.examplemod;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.common.Mod;
 
-@Mod(ExampleMod.MODID)
+@Mod(Constants.MODID)
 public class ExampleMod {
-    public static final String MODID = "examplemod";
-
     public ExampleMod() {
 //        ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, ServerConfig.SPEC);
     }
 
     public static ResourceLocation id(String path) {
-        return new ResourceLocation(MODID, path);
+        return new ResourceLocation(Constants.MODID, path);
     }
 }

--- a/1.19.2-forge/build.gradle.kts
+++ b/1.19.2-forge/build.gradle.kts
@@ -28,6 +28,7 @@ val modCredits: String by project
 
 dependencies {
     // Default Dependencies
+    implementation(project(":common"))
 
     // Mod Dependencies
 }

--- a/1.19.2-forge/src/main/java/net/meatwo310/examplemod/ExampleMod.java
+++ b/1.19.2-forge/src/main/java/net/meatwo310/examplemod/ExampleMod.java
@@ -3,15 +3,13 @@ package net.meatwo310.examplemod;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.common.Mod;
 
-@Mod(ExampleMod.MODID)
+@Mod(Constants.MODID)
 public class ExampleMod {
-    public static final String MODID = "examplemod";
-
     public ExampleMod() {
 //        ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, ServerConfig.SPEC);
     }
 
     public static ResourceLocation id(String path) {
-        return new ResourceLocation(MODID, path);
+        return new ResourceLocation(Constants.MODID, path);
     }
 }

--- a/1.20.1-forge/build.gradle.kts
+++ b/1.20.1-forge/build.gradle.kts
@@ -28,6 +28,7 @@ val modCredits: String by project
 
 dependencies {
     // Default Dependencies
+    implementation(project(":common"))
 
     // Mod Dependencies
 }

--- a/1.20.1-forge/src/main/java/net/meatwo310/examplemod/ExampleMod.java
+++ b/1.20.1-forge/src/main/java/net/meatwo310/examplemod/ExampleMod.java
@@ -4,15 +4,13 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
-@Mod(ExampleMod.MODID)
+@Mod(Constants.MODID)
 public class ExampleMod {
-    public static final String MODID = "examplemod";
-
     public ExampleMod(FMLJavaModLoadingContext ctx) {
 //        ctx.registerConfig(ModConfig.Type.SERVER, ServerConfig.SPEC);
     }
 
     public static ResourceLocation id(String path) {
-        return ResourceLocation.fromNamespaceAndPath(MODID, path);
+        return ResourceLocation.fromNamespaceAndPath(Constants.MODID, path);
     }
 }

--- a/1.21.1-neo/build.gradle.kts
+++ b/1.21.1-neo/build.gradle.kts
@@ -26,6 +26,7 @@ val modCredits: String by project
 
 dependencies {
     // Default Dependencies
+    implementation(project(":common"))
 
     // Mod Dependencies
 }

--- a/1.21.1-neo/src/main/java/net/meatwo310/examplemod/ExampleMod.java
+++ b/1.21.1-neo/src/main/java/net/meatwo310/examplemod/ExampleMod.java
@@ -5,15 +5,13 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 
-@Mod(ExampleMod.MODID)
+@Mod(Constants.MODID)
 public class ExampleMod {
-    public static final String MODID = "examplemod";
-
     public ExampleMod(IEventBus modEventBus, ModContainer modContainer) {
 //        modContainer.registerConfig(ModConfig.Type.SERVER, ServerConfig.SPEC);
     }
 
     public static ResourceLocation id(String path) {
-        return ResourceLocation.fromNamespaceAndPath(MODID, path);
+        return ResourceLocation.fromNamespaceAndPath(Constants.MODID, path);
     }
 }

--- a/1.21.1-neo/src/main/java/net/meatwo310/examplemod/client/ExampleModClient.java
+++ b/1.21.1-neo/src/main/java/net/meatwo310/examplemod/client/ExampleModClient.java
@@ -1,13 +1,13 @@
 package net.meatwo310.examplemod.client;
 
-import net.meatwo310.examplemod.ExampleMod;
+import net.meatwo310.examplemod.Constants;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 
-@Mod(value = ExampleMod.MODID, dist = Dist.CLIENT)
+@Mod(value = Constants.MODID, dist = Dist.CLIENT)
 public class ExampleModClient {
     public ExampleModClient(ModContainer container) {
         container.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);

--- a/26.1-fabric/build.gradle.kts
+++ b/26.1-fabric/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     minecraft("com.mojang:minecraft:$minecraftVersion")
     implementation("net.fabricmc:fabric-loader:$loaderVersion")
     implementation("net.fabricmc.fabric-api:fabric-api:$fabricApiVersion")
+    implementation(project(":common"))
 }
 
 java.toolchain {

--- a/26.1-fabric/src/main/java/net/meatwo310/examplemod/ExampleMod.java
+++ b/26.1-fabric/src/main/java/net/meatwo310/examplemod/ExampleMod.java
@@ -6,14 +6,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ExampleMod implements ModInitializer {
-    public static final String MODID = "examplemod";
-    public static final Logger LOGGER = LoggerFactory.getLogger(MODID);
+    public static final Logger LOGGER = LoggerFactory.getLogger(Constants.MODID);
 
     @Override
     public void onInitialize() {
     }
 
     public static Identifier id(String path) {
-        return Identifier.fromNamespaceAndPath(MODID, path);
+        return Identifier.fromNamespaceAndPath(Constants.MODID, path);
     }
 }

--- a/26.1-neo/build.gradle.kts
+++ b/26.1-neo/build.gradle.kts
@@ -23,6 +23,7 @@ val modCredits: String by project
 
 dependencies {
     // Default Dependencies
+    implementation(project(":common"))
 
     // Mod Dependencies
 }

--- a/26.1-neo/src/main/java/net/meatwo310/examplemod/ExampleMod.java
+++ b/26.1-neo/src/main/java/net/meatwo310/examplemod/ExampleMod.java
@@ -5,15 +5,13 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 
-@Mod(ExampleMod.MODID)
+@Mod(Constants.MODID)
 public class ExampleMod {
-    public static final String MODID = "examplemod";
-
     public ExampleMod(IEventBus modEventBus, ModContainer modContainer) {
 //        modContainer.registerConfig(ModConfig.Type.SERVER, ServerConfig.SPEC);
     }
 
     public static Identifier id(String path) {
-        return Identifier.fromNamespaceAndPath(MODID, path);
+        return Identifier.fromNamespaceAndPath(Constants.MODID, path);
     }
 }

--- a/26.1-neo/src/main/java/net/meatwo310/examplemod/client/ExampleModClient.java
+++ b/26.1-neo/src/main/java/net/meatwo310/examplemod/client/ExampleModClient.java
@@ -1,13 +1,13 @@
 package net.meatwo310.examplemod.client;
 
-import net.meatwo310.examplemod.ExampleMod;
+import net.meatwo310.examplemod.Constants;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 
-@Mod(value = ExampleMod.MODID, dist = Dist.CLIENT)
+@Mod(value = Constants.MODID, dist = Dist.CLIENT)
 public class ExampleModClient {
     public ExampleModClient(ModContainer container) {
         container.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `java-library`
+}
+
+java.toolchain {
+    languageVersion = JavaLanguageVersion.of(17)
+}

--- a/common/src/main/java/net/meatwo310/examplemod/Constants.java
+++ b/common/src/main/java/net/meatwo310/examplemod/Constants.java
@@ -1,0 +1,5 @@
+package net.meatwo310.examplemod;
+
+public final class Constants {
+    public static final String MODID = "examplemod";
+}

--- a/common/src/main/java/net/meatwo310/examplemod/Constants.java
+++ b/common/src/main/java/net/meatwo310/examplemod/Constants.java
@@ -1,5 +1,7 @@
 package net.meatwo310.examplemod;
 
 public final class Constants {
+    private Constants() {}
+    
     public static final String MODID = "examplemod";
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 
 rootProject.name = "custom-mdk"
 
+include("common")
 include("1.18.2-forge")
 include("1.19.2-forge")
 include("1.20.1-forge")


### PR DESCRIPTION
- New `common` subproject with `Constants.java` holding the single MODID field
- All six version subprojects now declare `implementation(project(":common"))`
- Removed per-subproject MODID fields; every reference updated to `Constants.MODID`

https://claude.ai/code/session_012VWxVBnGe7pUnqAfGR23Z5