### PR TITLE
Move Java version logging to root build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,14 @@ tasks.named<Wrapper>("wrapper").configure {
     distributionType = Wrapper.DistributionType.BIN
 }
 
+with(System.getProperties()) {
+    val version = get("java.version")
+    val vmVersion = get("java.vm.version")
+    val vendor = get("java.vendor")
+    val arch = get("os.arch")
+    println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
+}
+
 subprojects {
     val modVersion: String by project
     val modGroupId: String by project
@@ -59,14 +67,6 @@ subprojects {
 //            name = "ModMaven"
 //            url = uri("https://modmaven.dev/")
 //        }
-    }
-
-    with(System.getProperties()) {
-        val version = get("java.version")
-        val vmVersion = get("java.vm.version")
-        val vendor = get("java.vendor")
-        val arch = get("os.arch")
-        println("Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch")
     }
 
     tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
## Summary
Relocated the Java version and environment information logging from the subprojects configuration block to the root build script level. This ensures the diagnostic information is printed once during the initial build configuration rather than being repeated for each subproject.

## Key Changes
- Moved the Java system properties logging block (`java.version`, `java.vm.version`, `java.vendor`, `os.arch`) from inside the `subprojects` block to the root `build.gradle.kts`
- The logging now executes at the root level before subproject configuration begins
- Maintains the same diagnostic output format and information

## Implementation Details
- The logging block uses `System.getProperties()` to access JVM and system information
- Output format: `"Configuring with Java: $version, JVM: $vmVersion ($vendor), Arch: $arch"`
- This change improves build configuration clarity by showing environment details upfront and avoiding redundant logging across multiple subprojects

https://claude.ai/code/session_01TjSezHB2RfdPMSeZDADt2M