### PR TITLE
build scripts の依存関係と Fabric loader version を version catalog 化する

### DIFF
--- a/1.20.1-fabric/gradle.properties
+++ b/1.20.1-fabric/gradle.properties
@@ -1,5 +1,4 @@
 minecraftVersion=1.20.1
-loaderVersion=0.19.2
 fabricApiVersion=0.92.8+1.20.1
 javaVersion=17
 parchmentMinecraftVersion=1.20.1

--- a/1.21.1-fabric/gradle.properties
+++ b/1.21.1-fabric/gradle.properties
@@ -1,5 +1,4 @@
 minecraftVersion=1.21.1
-loaderVersion=0.19.2
 fabricApiVersion=0.116.11+1.21.1
 javaVersion=21
 parchmentMinecraftVersion=1.21.1

--- a/1.21.11-fabric/gradle.properties
+++ b/1.21.11-fabric/gradle.properties
@@ -1,5 +1,4 @@
 minecraftVersion=1.21.11
-loaderVersion=0.19.2
 fabricApiVersion=0.141.3+1.21.11
 javaVersion=21
 parchmentMinecraftVersion=1.21.11

--- a/1.21.8-fabric/gradle.properties
+++ b/1.21.8-fabric/gradle.properties
@@ -1,5 +1,4 @@
 minecraftVersion=1.21.8
-loaderVersion=0.19.2
 fabricApiVersion=0.136.1+1.21.8
 javaVersion=21
 parchmentMinecraftVersion=1.21.8

--- a/26.1-fabric/gradle.properties
+++ b/26.1-fabric/gradle.properties
@@ -1,4 +1,3 @@
 minecraftVersion=26.1
-loaderVersion=0.19.2
 fabricApiVersion=0.145.1+26.1
 javaVersion=25

--- a/26.1.2-fabric/gradle.properties
+++ b/26.1.2-fabric/gradle.properties
@@ -1,4 +1,3 @@
 minecraftVersion=26.1.2
-loaderVersion=0.19.2
 fabricApiVersion=0.148.0+26.1.2
 javaVersion=25

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,6 @@ repositories {
 }
 
 dependencies {
-    implementation("net.neoforged:moddev-gradle:2.0.141")
-    implementation("net.fabricmc:fabric-loom:1.16.1")
+    implementation(libs.neoforged.moddev.gradle)
+    implementation(libs.fabric.loom)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/VersionCatalogUtils.kt
+++ b/buildSrc/src/main/kotlin/VersionCatalogUtils.kt
@@ -1,0 +1,16 @@
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.provider.Provider
+
+fun VersionCatalog.library(alias: String): Provider<MinimalExternalModuleDependency> =
+    findLibrary(alias).orElseThrow {
+        IllegalArgumentException("Version catalog library '$alias' is not defined.")
+    }
+
+fun VersionCatalog.module(alias: String): String =
+    library(alias).get().module.toString()
+
+fun VersionCatalog.version(alias: String): String =
+    findVersion(alias).orElseThrow {
+        IllegalArgumentException("Version catalog version '$alias' is not defined.")
+    }.requiredVersion

--- a/buildSrc/src/main/kotlin/fabric-loom-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-loom-mod-conventions.gradle.kts
@@ -1,11 +1,13 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
 plugins {
     id("fabric-mod-conventions")
     id("net.fabricmc.fabric-loom")
 }
 
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 val modId: String by project
 val minecraftVersion: String by project
-val loaderVersion: String by project
 val fabricApiVersion: String by project
 
 val commonProject = ":$minecraftVersion-common"
@@ -33,9 +35,9 @@ loom {
 }
 
 dependencies {
-    minecraft("com.mojang:minecraft:$minecraftVersion")
-    implementation("net.fabricmc:fabric-loader:$loaderVersion")
-    implementation("net.fabricmc.fabric-api:fabric-api:$fabricApiVersion")
+    minecraft("${libs.module("minecraft")}:$minecraftVersion")
+    implementation(libs.library("fabric-loader"))
+    implementation("${libs.module("fabric-api")}:$fabricApiVersion")
 }
 
 fabricApi {

--- a/buildSrc/src/main/kotlin/fabric-loom-remap-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-loom-remap-mod-conventions.gradle.kts
@@ -1,11 +1,13 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
 plugins {
     id("fabric-mod-conventions")
     id("net.fabricmc.fabric-loom-remap")
 }
 
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 val modId: String by project
 val minecraftVersion: String by project
-val loaderVersion: String by project
 val fabricApiVersion: String by project
 val parchmentMinecraftVersion: String by project
 val parchmentMappingsVersion: String by project
@@ -32,12 +34,12 @@ loom {
 }
 
 dependencies {
-    minecraft("com.mojang:minecraft:$minecraftVersion")
+    minecraft("${libs.module("minecraft")}:$minecraftVersion")
     @Suppress("UnstableApiUsage")
     mappings(loom.layered {
         officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-$parchmentMinecraftVersion:$parchmentMappingsVersion@zip")
+        parchment("${libs.module("parchment-data")}-$parchmentMinecraftVersion:$parchmentMappingsVersion@zip")
     })
-    modImplementation("net.fabricmc:fabric-loader:$loaderVersion")
-    modImplementation("net.fabricmc.fabric-api:fabric-api:$fabricApiVersion")
+    modImplementation(libs.library("fabric-loader"))
+    modImplementation("${libs.module("fabric-api")}:$fabricApiVersion")
 }

--- a/buildSrc/src/main/kotlin/fabric-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-mod-conventions.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import groovy.json.JsonOutput
 
 plugins {
@@ -5,6 +6,7 @@ plugins {
     idea
 }
 
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 val modId: String by project
 val modName: String by project
 val modLicense: String by project
@@ -17,7 +19,6 @@ val modCredits: String by project
 val modFabricEntrypoint: String by project
 val modFabricClientEntrypoint: String by project
 val minecraftVersion: String by project
-val loaderVersion: String by project
 val javaVersion: String by project
 
 val commonProject = ":$minecraftVersion-common"
@@ -38,7 +39,7 @@ sourceSets.main.get().resources.srcDir(generatedModMetadataDir)
 val generateModMetadata = tasks.register<ProcessResources>("generateModMetadata") {
     val replaceProperties = mapOf(
         "minecraft_version" to JsonOutput.toJson("~$minecraftVersion"),
-        "loader_version" to JsonOutput.toJson(">=$loaderVersion"),
+        "loader_version" to JsonOutput.toJson(">=${libs.version("fabric-loader")}"),
         "mod_id" to JsonOutput.toJson(modId),
         "mod_name" to JsonOutput.toJson(modName),
         "mod_license" to JsonOutput.toJson(modLicense),

--- a/buildSrc/src/main/kotlin/legacyforge-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/legacyforge-mod-conventions.gradle.kts
@@ -1,9 +1,12 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
 plugins {
     `java-library`
     idea
     id("net.neoforged.moddev.legacyforge")
 }
 
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 val modId: String by project
 val modName: String by project
 val modLicense: String by project
@@ -28,7 +31,7 @@ evaluationDependsOn(sharedCommonProject)
 
 dependencies {
     implementation(project(commonProject))
-    annotationProcessor("org.spongepowered:mixin:0.8.5:processor")
+    annotationProcessor("${libs.module("mixin")}:${libs.version("mixin")}:processor")
 }
 
 sourceSets.main.get().resources {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     // Match the oldest supported loader classpath: 1.18.2 resolves slf4j-api to 1.8.0-beta4.
-    compileOnly("org.slf4j:slf4j-api:1.8.0-beta4")
+    compileOnly(libs.slf4j.api)
 }
 
 java.toolchain {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,16 @@
+[versions]
+fabric-loom = "1.16.1"
+fabric-loader = "0.19.2"
+mixin = "0.8.5"
+neoforged-moddev = "2.0.141"
+slf4j-api = "1.8.0-beta4"
+
+[libraries]
+fabric-api = { module = "net.fabricmc.fabric-api:fabric-api" }
+fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric-loader" }
+fabric-loom = { module = "net.fabricmc:fabric-loom", version.ref = "fabric-loom" }
+minecraft = { module = "com.mojang:minecraft" }
+mixin = { module = "org.spongepowered:mixin" }
+neoforged-moddev-gradle = { module = "net.neoforged:moddev-gradle", version.ref = "neoforged-moddev" }
+parchment-data = { module = "org.parchmentmc.data:parchment" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-api" }


### PR DESCRIPTION
## Summary
- `buildSrc` と各 Gradle Kotlin DSL から、ビルドスクリプト依存を version catalog 経由に寄せた
- Fabric の `loaderVersion` を `gradle/libs.versions.toml` に移し、各 Fabric サブプロジェクトの設定から個別定義を削除した
- `buildSrc` 側に version catalog を扱う共通ヘルパーを追加し、Kotlin DSL から参照しやすくした

## Testing
- `./gradlew help` で Gradle 設定の解決を確認
- `./gradlew build` で全体ビルドが通ることを確認