### PR TITLE
feat!: gate server runtime checks by Minecraft version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,20 +57,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Build with Gradle
-        run: chmod u+x ./gradlew && ./gradlew ":${{ matrix.subproject }}:build"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        if: ${{ !endsWith(matrix.subproject, 'common') }}
-        with:
-          path: ${{ matrix.subproject }}/build/libs/
-          name: artifact-${{ matrix.subproject }}
-
-      - name: Run Game Tests
-        if: "endsWith(matrix.subproject, 'neo') || endsWith(matrix.subproject, 'forge')"
-        run: ./gradlew ":${{ matrix.subproject }}:runGameTestServer"
-
       - name: Detect runtime test settings
         if: ${{ !endsWith(matrix.subproject, 'common') }}
         id: runtime
@@ -84,9 +70,18 @@ jobs:
           javaVersion="${javaVersion:-17}"
           fabricApiVersion="${fabricApiVersion%%+*}"
 
+          IFS='.' read -r mcMajor mcMinor _ <<< "$minecraftVersion"
+          mcMinor="${mcMinor:-0}"
+          if (( mcMajor > 26 || (mcMajor == 26 && mcMinor >= 1) )); then
+            supportsGameTestServer=true
+          else
+            supportsGameTestServer=false
+          fi
+
           echo "mc=$minecraftVersion" >> "$GITHUB_OUTPUT"
           echo "java=$javaVersion" >> "$GITHUB_OUTPUT"
           echo "fabric_api=${fabricApiVersion:-none}" >> "$GITHUB_OUTPUT"
+          echo "supports_game_test_server=$supportsGameTestServer" >> "$GITHUB_OUTPUT"
 
           if [[ "$loader" == "neo" ]]; then
             echo "modloader=neoforge" >> "$GITHUB_OUTPUT"
@@ -97,6 +92,26 @@ jobs:
             echo "mc_runtime_test=${loader/forge/lexforge}" >> "$GITHUB_OUTPUT"
             echo "regex=.*$loader.*" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Build with Gradle
+        run: chmod u+x ./gradlew && ./gradlew ":${{ matrix.subproject }}:build"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        if: ${{ !endsWith(matrix.subproject, 'common') }}
+        with:
+          path: ${{ matrix.subproject }}/build/libs/
+          name: artifact-${{ matrix.subproject }}
+
+      - name: Run Game Tests
+        if: ${{ !endsWith(matrix.subproject, 'common') && steps.runtime.outputs.supports_game_test_server == 'true' && (endsWith(matrix.subproject, 'neo') || endsWith(matrix.subproject, 'forge')) }}
+        timeout-minutes: 10
+        run: ./gradlew ":${{ matrix.subproject }}:runGameTestServer"
+
+      - name: Run Server
+        if: ${{ !endsWith(matrix.subproject, 'common') && steps.runtime.outputs.supports_game_test_server != 'true' }}
+        timeout-minutes: 10
+        run: echo stop | ./gradlew ":${{ matrix.subproject }}:runServer"
 
       - name: Setup runtime JDK
         if: ${{ !endsWith(matrix.subproject, 'common') }}
@@ -121,6 +136,7 @@ jobs:
 
       - name: Run MC runtime test client
         if: ${{ !endsWith(matrix.subproject, 'common') }}
+        timeout-minutes: 10
         uses: headlesshq/mc-runtime-test@4.4.0
         with:
           mc: ${{ steps.runtime.outputs.mc }}

--- a/buildSrc/src/main/kotlin/MinecraftVersionSupport.kt
+++ b/buildSrc/src/main/kotlin/MinecraftVersionSupport.kt
@@ -1,0 +1,6 @@
+fun String.supportsGameTestServer(): Boolean {
+    val parts = split(".").mapNotNull(String::toIntOrNull)
+    val major = parts.getOrElse(0) { 0 }
+    val minor = parts.getOrElse(1) { 0 }
+    return major > 26 || (major == 26 && minor >= 1)
+}

--- a/buildSrc/src/main/kotlin/fabric-loom-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-loom-mod-conventions.gradle.kts
@@ -37,15 +37,17 @@ dependencies {
     implementation("${versionCatalog.module(VersionCatalogLibrary.FabricApi)}:$fabricApiVersion")
 }
 
-fabricApi {
-    val testModId = "$modId-test"
+if (minecraftVersion.supportsGameTestServer()) {
+    fabricApi {
+        val testModId = "$modId-test"
 
-    @Suppress("UnstableApiUsage")
-    configureTests {
-        createSourceSet = true
-        modId = testModId
-        enableGameTests = true
-        enableClientGameTests = true
-        eula = true
+        @Suppress("UnstableApiUsage")
+        configureTests {
+            createSourceSet = true
+            modId = testModId
+            enableGameTests = true
+            enableClientGameTests = true
+            eula = true
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/legacyforge-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/legacyforge-mod-conventions.gradle.kts
@@ -73,9 +73,11 @@ legacyForge {
             systemProperty("forge.enabledGameTestNamespaces", modId)
         }
 
-        create("gameTestServer") {
-            type = "gameTestServer"
-            systemProperty("forge.enabledGameTestNamespaces", modId)
+        if (minecraftVersion.supportsGameTestServer()) {
+            create("gameTestServer") {
+                type = "gameTestServer"
+                systemProperty("forge.enabledGameTestNamespaces", modId)
+            }
         }
 
         create("data") {

--- a/buildSrc/src/main/kotlin/neoforge-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/neoforge-mod-conventions.gradle.kts
@@ -74,9 +74,11 @@ neoForge {
             systemProperty("neoforge.enabledGameTestNamespaces", modId)
         }
 
-        create("gameTestServer") {
-            type = "gameTestServer"
-            systemProperty("neoforge.enabledGameTestNamespaces", modId)
+        if (minecraftVersion.supportsGameTestServer()) {
+            create("gameTestServer") {
+                type = "gameTestServer"
+                systemProperty("neoforge.enabledGameTestNamespaces", modId)
+            }
         }
 
         create("data") {


### PR DESCRIPTION
## Summary
- Gate GameTest Server support to Minecraft 26.1 and newer in Gradle conventions.
- Share the Minecraft version gate through `MinecraftVersionSupport.kt` instead of duplicating it in each convention script.
- Use `runServer` with stdin `stop` for CI server runtime checks on versions older than 26.1.
- Keep server-side runtime checks before the MC runtime test client step, with 10 minute timeouts for GameTest, runServer, and the runtime test client.

## Why
Minecraft versions older than 26.1 can crash when Fabric receives an empty GameTest setup, while Minecraft 26.1 and newer can crash when `runServer` consumes a pre-supplied `stop` command immediately after startup. The CI now chooses the safer server check per Minecraft version.

## Breaking Change
GameTest Server runs and Fabric GameTest configuration are no longer created for Minecraft versions older than 26.1, and CI server runtime checks now branch by Minecraft version.

## Validation
- Parsed `.github/workflows/build.yml` as YAML.
- Ran `./gradlew :buildSrc:compileKotlin --console=plain`.
- Verified `runGameTestServer` is absent for `:1.21.1-neo` and `:1.20.1-forge`.
- Verified `runGameTestServer` remains available for `:26.1-neo`.
- Verified Fabric build task wiring for `:1.21.11-fabric` and `:26.1-fabric` with dry runs.