### PR TITLE
[codex] detectジョブでbuild matrixメタデータを生成する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
+      count: ${{ steps.detect.outputs.count }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -42,18 +43,21 @@ jobs:
           ./gradlew --configuration-cache --no-daemon writeCiBuildMatrix
           JSON=$(<build/ci/build-matrix.json)
           echo "matrix=$(jq -c '.' <<< "$JSON")" >> "$GITHUB_OUTPUT"
+          echo "count=$(jq 'length' <<< "$JSON")" >> "$GITHUB_OUTPUT"
           echo "::group::Platform projects"
           jq . <<< "$JSON"
           echo "::endgroup::"
 
   build:
     needs: detect
+    if: ${{ needs.detect.outputs.count != '0' }}
+    name: build (${{ matrix.subproject }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        subproject: ${{ fromJson(needs.detect.outputs.matrix) }}
+        include: ${{ fromJson(needs.detect.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -72,49 +76,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Detect runtime test settings
-        if: ${{ !endsWith(matrix.subproject, 'common') }}
-        id: runtime
-        run: |
-          subproject="${{ matrix.subproject }}"
-          prop() { sed -n "s/^$1=//p" "$subproject/gradle.properties"; }
-          loader="${subproject##*-}"
-          minecraftVersion="$(prop minecraftVersion)"
-          javaVersion="$(prop javaVersion)"
-          fabricApiVersion="$(prop fabricApiVersion)"
-          javaVersion="${javaVersion:-17}"
-          fabricApiVersion="${fabricApiVersion%%+*}"
-
-          IFS='.' read -r mcMajor mcMinor mcPatch <<< "$minecraftVersion"
-          mcMinor="${mcMinor:-0}"
-          mcPatch="${mcPatch:-0}"
-          if (( mcMajor > 26 || (mcMajor == 26 && mcMinor >= 1) || (mcMajor == 1 && mcMinor == 21 && mcPatch >= 11) )); then
-            supportsGameTestServer=true
-          else
-            supportsGameTestServer=false
-          fi
-
-          echo "mc=$minecraftVersion" >> "$GITHUB_OUTPUT"
-          echo "java=$javaVersion" >> "$GITHUB_OUTPUT"
-          echo "fabric_api=${fabricApiVersion:-none}" >> "$GITHUB_OUTPUT"
-          echo "supports_game_test_server=$supportsGameTestServer" >> "$GITHUB_OUTPUT"
-
-          if [[ "$loader" == "neo" ]]; then
-            echo "modloader=neoforge" >> "$GITHUB_OUTPUT"
-            echo "mc_runtime_test=neoforge" >> "$GITHUB_OUTPUT"
-            echo "regex=.*neoforge.*" >> "$GITHUB_OUTPUT"
-          else
-            echo "modloader=$loader" >> "$GITHUB_OUTPUT"
-            echo "mc_runtime_test=${loader/forge/lexforge}" >> "$GITHUB_OUTPUT"
-            echo "regex=.*$loader.*" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Build with Gradle
         run: chmod u+x ./gradlew && ./gradlew ":${{ matrix.subproject }}:build"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
-        if: ${{ !endsWith(matrix.subproject, 'common') }}
         with:
           path: |
             ${{ matrix.subproject }}/build/libs/
@@ -123,12 +89,12 @@ jobs:
 
       # Fabric Game Tests are run implicitly by the build task.
       - name: Run NeoForge/Forge Game Tests
-        if: ${{ !endsWith(matrix.subproject, 'common') && steps.runtime.outputs.supports_game_test_server == 'true' && (endsWith(matrix.subproject, 'neo') || endsWith(matrix.subproject, 'forge')) }}
+        if: ${{ matrix.run_game_test_server }}
         timeout-minutes: 10
         run: ./gradlew ":${{ matrix.subproject }}:runGameTestServer"
 
       - name: Run Server
-        if: ${{ !endsWith(matrix.subproject, 'common') && steps.runtime.outputs.supports_game_test_server != 'true' }}
+        if: ${{ matrix.run_server }}
         timeout-minutes: 10
         run: |
           mkdir -p "${{ matrix.subproject }}/run"
@@ -136,16 +102,14 @@ jobs:
           echo stop | ./gradlew ":${{ matrix.subproject }}:runServer"
 
       - name: Setup runtime JDK
-        if: ${{ !endsWith(matrix.subproject, 'common') }}
         uses: actions/setup-java@v5
         with:
-          java-version: ${{ steps.runtime.outputs.java }}
+          java-version: ${{ matrix.java }}
           distribution: 'temurin'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Stage mod for runtime test client
-        if: ${{ !endsWith(matrix.subproject, 'common') }}
         run: |
           mkdir -p run/mods
           find "${{ matrix.subproject }}/build/libs" -maxdepth 1 -type f -name '*.jar' \
@@ -161,13 +125,12 @@ jobs:
           ls -la run/mods
 
       - name: Run MC runtime test client
-        if: ${{ !endsWith(matrix.subproject, 'common') }}
         timeout-minutes: 10
         uses: headlesshq/mc-runtime-test@4.4.0
         with:
-          mc: ${{ steps.runtime.outputs.mc }}
-          modloader: ${{ steps.runtime.outputs.modloader }}
-          regex: ${{ steps.runtime.outputs.regex }}
-          mc-runtime-test: ${{ steps.runtime.outputs.mc_runtime_test }}
-          java: ${{ steps.runtime.outputs.java }}
-          fabric-api: ${{ steps.runtime.outputs.fabric_api }}
+          mc: ${{ matrix.minecraft }}
+          modloader: ${{ matrix.modloader }}
+          regex: ${{ matrix.artifact_regex }}
+          mc-runtime-test: ${{ matrix.mc_runtime_test }}
+          java: ${{ matrix.java }}
+          fabric-api: ${{ matrix.fabric_api }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import groovy.json.JsonOutput
+import net.meatwo310.mdk.build.supportsGameTestServer
 import org.gradle.plugins.ide.idea.model.IdeaModel
 
 plugins {
@@ -16,12 +17,71 @@ tasks.register("writeCiBuildMatrix") {
     val outputFile = layout.buildDirectory.file("ci/build-matrix.json")
     val ciBuildProjects = (gradle.extensions.extraProperties["ciBuildProjectNames"] as List<*>)
         .map { it.toString() }
+    val supportedLoaders = setOf("fabric", "forge", "neo")
+
+    val duplicates = ciBuildProjects
+        .groupingBy { it }
+        .eachCount()
+        .filterValues { it > 1 }
+        .keys
+    if (duplicates.isNotEmpty()) {
+        throw GradleException("Duplicate CI build projects: ${duplicates.joinToString()}")
+    }
+
+    val ciBuildMatrix = ciBuildProjects.map { projectName ->
+        val targetProject = project(":$projectName")
+        val minecraftVersion = targetProject.property("minecraftVersion").toString()
+        val loader = projectName.substringAfterLast("-")
+        val javaVersion = targetProject.findProperty("javaVersion")?.toString() ?: "17"
+        val fabricApiVersion = targetProject.findProperty("fabricApiVersion")
+            ?.toString()
+            ?.substringBefore("+")
+            ?: "none"
+        val modloader = if (loader == "neo") "neoforge" else loader
+        val mcRuntimeTest = when (loader) {
+            "forge" -> "lexforge"
+            "neo" -> "neoforge"
+            else -> loader
+        }
+        val supportsGameTestServer = minecraftVersion.supportsGameTestServer()
+        val commonProjectName = "$minecraftVersion-common"
+
+        if (loader !in supportedLoaders) {
+            throw GradleException("Unsupported loader '$loader' in CI build project '$projectName'")
+        }
+        if (minecraftVersion.isBlank()) {
+            throw GradleException("Project '$projectName' must define minecraftVersion")
+        }
+        if (!rootProject.childProjects.containsKey(commonProjectName)) {
+            throw GradleException("Project '$projectName' references missing common project '$commonProjectName'")
+        }
+        if (!javaVersion.matches(Regex("\\d+"))) {
+            throw GradleException("Project '$projectName' has invalid javaVersion '$javaVersion'")
+        }
+        if (loader == "fabric" && fabricApiVersion == "none") {
+            throw GradleException("Fabric project '$projectName' must define fabricApiVersion")
+        }
+
+        mapOf(
+            "subproject" to projectName,
+            "loader" to loader,
+            "minecraft" to minecraftVersion,
+            "java" to javaVersion,
+            "fabric_api" to fabricApiVersion,
+            "supports_game_test_server" to supportsGameTestServer,
+            "run_game_test_server" to (supportsGameTestServer && loader in setOf("forge", "neo")),
+            "run_server" to !supportsGameTestServer,
+            "modloader" to modloader,
+            "mc_runtime_test" to mcRuntimeTest,
+            "artifact_regex" to ".*$loader.*",
+        )
+    }
 
     outputs.file(outputFile)
-    inputs.property("ciBuildProjects", ciBuildProjects)
+    inputs.property("ciBuildMatrix", ciBuildMatrix)
 
     doLast {
-        val json = JsonOutput.toJson(ciBuildProjects)
+        val json = JsonOutput.toJson(ciBuildMatrix)
         outputFile.get().asFile.apply {
             parentFile.mkdirs()
             writeText(json)


### PR DESCRIPTION
## Summary
- Generate the build matrix as structured metadata from Gradle in the detect job
- Move runtime-test settings and validation into `writeCiBuildMatrix`
- Simplify the build job to consume `matrix.*` values directly

## Why
The build workflow previously re-read project properties with shell parsing in each matrix job and duplicated Gradle-side version support logic. Centralizing that in detect makes CI behavior easier to validate early and keeps the build job focused on execution.

## Validation
- `./gradlew.bat --configuration-cache --no-daemon writeCiBuildMatrix`
- `git diff --check`