### PR TITLE
[codex] NeoForge artifact名とFabric API conventionを整理

### DIFF
--- a/1.20.1-fabric/build.gradle.kts
+++ b/1.20.1-fabric/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("fabric-loom-remap-mod-conventions")
+    id("fabric-api-conventions")
     id("fabric-config-conventions")
 }
 

--- a/1.21.1-fabric/build.gradle.kts
+++ b/1.21.1-fabric/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("fabric-loom-remap-mod-conventions")
+    id("fabric-api-conventions")
     id("fabric-config-conventions")
 }
 

--- a/1.21.11-fabric/build.gradle.kts
+++ b/1.21.11-fabric/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("fabric-loom-remap-mod-conventions")
+    id("fabric-api-conventions")
     id("fabric-config-conventions")
 }
 

--- a/1.21.8-fabric/build.gradle.kts
+++ b/1.21.8-fabric/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("fabric-loom-remap-mod-conventions")
+    id("fabric-api-conventions")
     id("fabric-config-conventions")
 }
 

--- a/26.1-fabric/build.gradle.kts
+++ b/26.1-fabric/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("fabric-loom-mod-conventions")
+    id("fabric-api-conventions")
     id("fabric-config-conventions")
 }
 

--- a/26.1.2-fabric/build.gradle.kts
+++ b/26.1.2-fabric/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("fabric-loom-mod-conventions")
+    id("fabric-api-conventions")
     id("fabric-config-conventions")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,10 +58,6 @@ tasks.register("writeCiBuildMatrix") {
         if (!javaVersion.matches(Regex("\\d+"))) {
             throw GradleException("Project '$projectName' has invalid javaVersion '$javaVersion'")
         }
-        if (loader == "fabric" && fabricApiVersion == "none") {
-            throw GradleException("Fabric project '$projectName' must define fabricApiVersion")
-        }
-
         mapOf(
             "subproject" to projectName,
             "loader" to loader,

--- a/buildSrc/src/main/kotlin/fabric-api-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-api-conventions.gradle.kts
@@ -1,0 +1,39 @@
+import net.fabricmc.loom.api.fabricapi.FabricApiExtension
+import net.meatwo310.mdk.build.*
+
+val modId: String by project
+val minecraftVersion: String by project
+val fabricApiVersion: String by project
+
+plugins.withId("fabric-mod-conventions") {
+    extensions.configure<FabricModMetadataExtension>("fabricModMetadata") {
+        depend("fabric-api", "*")
+    }
+}
+
+fun configureFabricApiTests() {
+    if (minecraftVersion.supportsGameTestServer()) {
+        extensions.configure<FabricApiExtension>("fabricApi") {
+            val testModId = "$modId-test"
+
+            @Suppress("UnstableApiUsage")
+            configureTests {
+                createSourceSet = true
+                modId = testModId
+                enableGameTests = true
+                enableClientGameTests = true
+                eula = true
+            }
+        }
+    }
+}
+
+plugins.withId("net.fabricmc.fabric-loom") {
+    dependencies.add("implementation", "${versionCatalog.module(VersionCatalogLibrary.FabricApi)}:$fabricApiVersion")
+    configureFabricApiTests()
+}
+
+plugins.withId("net.fabricmc.fabric-loom-remap") {
+    dependencies.add("modImplementation", "${versionCatalog.module(VersionCatalogLibrary.FabricApi)}:$fabricApiVersion")
+    configureFabricApiTests()
+}

--- a/buildSrc/src/main/kotlin/fabric-loom-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-loom-mod-conventions.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 
 val modId: String by project
 val minecraftVersion: String by project
-val fabricApiVersion: String by project
 
 val commonProject = ":$minecraftVersion-common"
 val sharedCommonProject = ":common"
@@ -36,20 +35,4 @@ loom {
 dependencies {
     minecraft("${versionCatalog.module(VersionCatalogLibrary.Minecraft)}:$minecraftVersion")
     implementation(versionCatalog.library(VersionCatalogLibrary.FabricLoader))
-    implementation("${versionCatalog.module(VersionCatalogLibrary.FabricApi)}:$fabricApiVersion")
-}
-
-if (minecraftVersion.supportsGameTestServer()) {
-    fabricApi {
-        val testModId = "$modId-test"
-
-        @Suppress("UnstableApiUsage")
-        configureTests {
-            createSourceSet = true
-            modId = testModId
-            enableGameTests = true
-            enableClientGameTests = true
-            eula = true
-        }
-    }
 }

--- a/buildSrc/src/main/kotlin/fabric-loom-remap-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-loom-remap-mod-conventions.gradle.kts
@@ -1,7 +1,6 @@
 import net.meatwo310.mdk.build.VersionCatalogLibrary
 import net.meatwo310.mdk.build.library
 import net.meatwo310.mdk.build.module
-import net.meatwo310.mdk.build.supportsGameTestServer
 import net.meatwo310.mdk.build.versionCatalog
 
 plugins {
@@ -11,7 +10,6 @@ plugins {
 
 val modId: String by project
 val minecraftVersion: String by project
-val fabricApiVersion: String by project
 val parchmentMinecraftVersion: String by project
 val parchmentMappingsVersion: String by project
 
@@ -47,20 +45,4 @@ dependencies {
         parchment("${versionCatalog.module(VersionCatalogLibrary.ParchmentData)}-$parchmentMinecraftVersion:$parchmentMappingsVersion@zip")
     })
     modImplementation(versionCatalog.library(VersionCatalogLibrary.FabricLoader))
-    modImplementation("${versionCatalog.module(VersionCatalogLibrary.FabricApi)}:$fabricApiVersion")
-}
-
-if (minecraftVersion.supportsGameTestServer()) {
-    fabricApi {
-        val testModId = "$modId-test"
-
-        @Suppress("UnstableApiUsage")
-        configureTests {
-            createSourceSet = true
-            modId = testModId
-            enableGameTests = true
-            enableClientGameTests = true
-            eula = true
-        }
-    }
 }

--- a/buildSrc/src/main/kotlin/fabric-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-mod-conventions.gradle.kts
@@ -42,7 +42,6 @@ fabricModMetadata.depends.putAll(linkedMapOf(
     "fabricloader" to ">=${versionCatalog.version(VersionCatalogVersion.FabricLoader)}",
     "minecraft" to "~$minecraftVersion",
     "java" to ">=$javaVersion",
-    "fabric-api" to "*",
 ))
 
 fun defaultModMetadata(fabricDependencies: Map<String, String>) = linkedMapOf<String, Any?>(

--- a/buildSrc/src/main/kotlin/neoforge-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/neoforge-mod-conventions.gradle.kts
@@ -41,7 +41,7 @@ sourceSets.main.get().resources {
 }
 
 base {
-    archivesName = "$modId-$minecraftVersion-neo"
+    archivesName = "$modId-$minecraftVersion-neoforge"
 }
 
 java.toolchain {


### PR DESCRIPTION
## 概要

- NeoForge版の jar artifact 名を `*-neo-*` から `*-neoforge-*` に変更しました。
- Fabric API の依存追加、`fabric.mod.json` の depends、GameTest 設定を `fabric-api-conventions` に分離しました。
- 既存の Fabric サブプロジェクトには `fabric-api-conventions` を明示適用し、現在の挙動を維持しています。

## 補足

`id("fabric-api-conventions")` を外した場合、代表プロジェクトでは jar ビルドは通り、生成された `fabric.mod.json` から `fabric-api` depends は消えることを確認しました。一方、`fabric-config-conventions` を併用している場合は `forgeconfigapiport-fabric` の推移依存として Fabric API が依存グラフに残ります。

## 検証

- `./gradlew --configuration-cache --no-daemon :26.1.2-neo:jar`
- `./gradlew --configuration-cache --no-daemon writeCiBuildMatrix :26.1.2-fabric:jar`
- `./gradlew --configuration-cache --no-daemon :1.20.1-fabric:jar`
- 一時的に `fabric-api-conventions` を外して `:26.1.2-fabric:jar` / `:1.20.1-fabric:jar` と dependency insight を確認
- `git diff --check`