### PR TITLE
[codex] Add LLM-oriented MDK documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@ A Minecraft mod template for multi-version and multi-loader development, powered
 
 Only the subprojects included in `settings.gradle.kts` are configured. Remove unused `include(...)` lines when you do not need a version or loader.
 
+LLM agents and automation should also read [MDK Agent Notes](mdk/README.md) before editing this template.
+
 ## Project Layout
 
 - `common`: shared Java code used by every supported target.
@@ -34,6 +36,8 @@ Only the subprojects included in `settings.gradle.kts` are configured. Remove un
 - `version.txt`: the mod version used for project versions, artifact names, and generated metadata.
 
 ## Setup
+
+Before opening or importing the project in IntelliJ IDEA or Gradle, trim `settings.gradle.kts`: each included project adds Gradle configuration and IDE import load time. Comment out or remove any unused `include(...)` lines first.
 
 1. Click **Use this template** on GitHub to create your repository from this template.
 2. If you want to keep receiving template updates, initialize upstream tracking
@@ -76,7 +80,7 @@ Build a specific platform:
 
 ```sh
 ./gradlew :26.1.2-fabric:build
-./gradlew :26.1.2-forge:build
+./gradlew :26.1.2-neo:build
 ```
 
 Artifacts are written to `<subproject>/build/libs/`. Additional runtime-only mod jars declared through `runtimeMods` are collected in `<subproject>/build/runtimeMods/` for CI.

--- a/docs/mdk/README.md
+++ b/docs/mdk/README.md
@@ -1,0 +1,92 @@
+# MDK Agent Notes
+
+This directory is a compact operating guide for LLM agents working on this
+multi-version, multi-loader Minecraft mod template.
+
+Keep the docs practical. Prefer project-specific facts over general Minecraft
+modding explanations, and update these files when project structure or build
+commands change.
+
+## Read Order
+
+1. `README.md` - start here for scope and navigation.
+2. `project-map.md` - locate the owning project, source set, or template.
+3. `workflow.md` - follow the normal edit and verification flow.
+4. `change-recipes.md` - use the checklist that matches the requested change.
+
+## Repository Shape
+
+The Gradle build is split by Minecraft version and loader:
+
+- `common` contains cross-version shared code.
+- `<mc>-common` contains code shared by loaders for one Minecraft version.
+- `<mc>-fabric` contains Fabric loader code and metadata for one version.
+- `<mc>-forge` contains Legacy Forge loader code and metadata for one version.
+- `<mc>-neo` contains NeoForge loader code and metadata for one version.
+- `buildSrc` owns reusable Gradle convention plugins and helper tasks.
+
+The active project list is defined in `settings.gradle.kts`. Do not infer
+supported versions from directory names alone; check the `include(...)` entries.
+
+Current included projects:
+
+- `common`
+- `1.18.2-common`, `1.18.2-forge`
+- `1.19.2-common`, `1.19.2-forge`
+- `1.20.1-common`, `1.20.1-forge`, `1.20.1-fabric`
+- `1.21.1-common`, `1.21.1-neo`, `1.21.1-fabric`
+- `1.21.8-common`, `1.21.8-fabric`
+- `1.21.11-common`, `1.21.11-fabric`
+- `26.1-common`, `26.1-fabric`, `26.1-neo`
+- `26.1.2-common`, `26.1.2-fabric`, `26.1.2-neo`
+
+## Key Build Inputs
+
+- `gradle.properties` stores global mod metadata such as `modId`, `modName`,
+  group, license, URLs, authors, and Fabric entrypoints.
+- `version.txt` stores the release version used by all subprojects.
+- Each subproject `gradle.properties` stores the target Minecraft version,
+  loader versions, Java version, mappings, and runtime dependency versions.
+- `gradle/libs.versions.toml` stores shared plugin and dependency aliases.
+- `settings.gradle.kts` controls which projects exist and which loader projects
+  are included in the CI build matrix.
+
+## Generated Metadata
+
+Loader metadata is generated during Gradle resource processing:
+
+- Fabric reads `src/main/templates/fabric.mod.json` and writes generated
+  metadata with default dependencies from `fabric-mod-conventions`.
+- Legacy Forge reads `src/main/templates/META-INF/mods.toml`.
+- NeoForge reads `src/main/templates/META-INF/neoforge.mods.toml`.
+- Forge and NeoForge also include generated resources from
+  `src/generated/resources`.
+
+Edit templates when changing metadata structure. Edit Gradle properties when
+changing values.
+
+## CI And Release
+
+The `Build` workflow ignores docs-only changes. For code changes, it:
+
+- runs `./gradlew --configuration-cache --no-daemon writeCiBuildMatrix`;
+- builds every loader project detected from `settings.gradle.kts`;
+- uploads each loader project's `build/libs` and `build/runtimeMods`;
+- runs Forge/NeoForge game tests when supported;
+- otherwise starts a server smoke test;
+- runs `headlesshq/mc-runtime-test` against the built jars.
+
+The `Release` workflow is manual. It can bump `version.txt`, build all platform
+projects, collect release jars under `build/release/libs`, generate notes with
+`git-cliff`, tag `v<version>`, and create a GitHub Release.
+
+## Agent Rules
+
+- Keep edits scoped to the requested version, loader, and source set.
+- Never remove another version or loader unless the task explicitly asks for it.
+- When adding a new platform project, update `settings.gradle.kts`, the
+  subproject files, properties, templates, and CI expectations together.
+- Prefer existing convention plugins in `buildSrc` over ad hoc Gradle logic in
+  individual subprojects.
+- For config-related work, check `src/config` and `src/configClient` in
+  addition to `src/main` and `src/client`.

--- a/docs/mdk/change-recipes.md
+++ b/docs/mdk/change-recipes.md
@@ -1,0 +1,142 @@
+# Change Recipes
+
+Use the checklist closest to the requested change. Keep scope narrow unless the
+request explicitly asks for a broad update.
+
+## Add Shared Mod Code
+
+- Decide whether the code is cross-version (`common/src/main`) or tied to one
+  Minecraft version (`<mc>-common/src/main`).
+- Keep package names aligned with existing `net.meatwo310.examplemod` classes.
+- If the shared API changes, update every loader project that calls it.
+- Build representative downstream projects:
+
+```bash
+./gradlew :1.18.2-forge:build :1.20.1-fabric:build :26.1-neo:build
+```
+
+## Add Loader-Specific Code
+
+- Put Fabric code under `<mc>-fabric`, Legacy Forge code under `<mc>-forge`, and
+  NeoForge code under `<mc>-neo`.
+- Keep entrypoint names consistent with `gradle.properties` and metadata
+  templates.
+- For Fabric client code, use `src/client/java`.
+- For Forge and NeoForge client-only code, follow the existing project pattern
+  before adding a new source set.
+- Build the affected project:
+
+```bash
+./gradlew :<mc>-<loader>:build
+```
+
+## Add Or Change Config
+
+- Put shared declarations in `common/src/config`.
+- Put version-specific config helpers in `<mc>-common/src/config`.
+- Put loader config registrar code in `<mc>-<loader>/src/config`.
+- Put client config UI code in `<mc>-<loader>/src/configClient` when that loader
+  convention supports it.
+- Confirm the affected project applies the right `*-config-conventions` plugin.
+- For Fabric config dependencies, check Forge Config API Port and any runtime UI
+  mods such as Mod Menu or Forge Config Screens.
+- Build one affected project per loader family.
+
+## Add A New Minecraft Version
+
+- Add `<mc>-common`.
+- Add one or more loader projects: `<mc>-fabric`, `<mc>-forge`, `<mc>-neo`.
+- Add `include(...)` entries in `settings.gradle.kts`.
+- Add each subproject `build.gradle.kts`.
+- Add each subproject `gradle.properties` with `minecraftVersion` and required
+  loader, Java, mapping, and dependency versions.
+- Copy only the needed source files from the nearest existing version, then
+  adapt API differences.
+- Add metadata templates under each loader project's `src/main/templates`.
+- Run:
+
+```bash
+./gradlew --configuration-cache --no-daemon writeCiBuildMatrix
+./gradlew :<mc>-common:build :<mc>-<loader>:build
+```
+
+## Add A New Loader Project For An Existing Version
+
+- Confirm `<mc>-common` exists and is included.
+- Add `<mc>-fabric`, `<mc>-forge`, or `<mc>-neo`.
+- Add the project to `settings.gradle.kts`.
+- Use the matching convention plugins:
+  - Fabric: `fabric-loom-mod-conventions` or `fabric-loom-remap-mod-conventions`
+  - Fabric API: `fabric-api-conventions`
+  - Fabric config: `fabric-config-conventions`
+  - Legacy Forge: `legacyforge-mod-conventions`
+  - Legacy Forge config: `legacyforge-config-conventions`
+  - NeoForge: `neoforge-mod-conventions`
+  - NeoForge config: `neoforge-config-conventions`
+- Add loader metadata templates and runtime dependencies.
+- Run `writeCiBuildMatrix` and the new project build.
+
+## Change Mod Metadata Values
+
+- Prefer root `gradle.properties` for shared values such as mod id, name,
+  license, authors, URLs, credits, and Fabric entrypoints.
+- Prefer subproject `gradle.properties` for Minecraft, loader, Java, mappings,
+  and runtime dependency versions.
+- Edit templates only when the metadata shape changes.
+- Build one Fabric and one Forge/NeoForge project if template expansion changed.
+
+## Change Metadata Template Structure
+
+- Fabric: edit `src/main/templates/fabric.mod.json` and check
+  `fabric-mod-conventions`.
+- Legacy Forge: edit `src/main/templates/META-INF/mods.toml` and check
+  `legacyforge-mod-conventions`.
+- NeoForge: edit `src/main/templates/META-INF/neoforge.mods.toml` and check
+  `neoforge-mod-conventions`.
+- If a new placeholder is introduced, add it to the matching `replaceProperties`
+  or default metadata map.
+- Run the affected loader project build and inspect generated resources if the
+  change is risky.
+
+## Change Dependencies
+
+- Use `gradle/libs.versions.toml` for shared aliases.
+- Use subproject `gradle.properties` for per-version dependency versions.
+- Add runtime-only mod dependencies in the affected loader project's
+  `build.gradle.kts`.
+- For external runtime-test-only jars, use the existing `runtimeMods`
+  configuration where appropriate.
+- Build the affected project and confirm `build/runtimeMods` when runtime mods
+  are expected.
+
+## Change buildSrc Conventions
+
+- Identify which convention plugin owns the behavior.
+- Keep common behavior in helper functions under `net/meatwo310/mdk/build`.
+- Avoid duplicating logic across Fabric, Forge, and NeoForge conventions unless
+  their Gradle plugins require different APIs.
+- Run at least:
+
+```bash
+./gradlew --configuration-cache --no-daemon writeCiBuildMatrix
+./gradlew :1.20.1-fabric:build :1.20.1-forge:build :26.1-neo:build
+```
+
+## Change CI Or Release Behavior
+
+- For build matrix behavior, update `writeCiBuildMatrix` in root
+  `build.gradle.kts`.
+- For workflow execution behavior, update `.github/workflows/build.yml`.
+- For version bumping, jar collection, release notes, tags, or GitHub Release
+  behavior, update `.github/workflows/release.yml`.
+- Run `writeCiBuildMatrix` locally after matrix-related changes.
+- Check that docs-only changes are still ignored by the build workflow unless
+  the requested change says otherwise.
+
+## Change Release Version
+
+- Edit `version.txt` only when intentionally setting the release version.
+- Keep the value as a plain semantic version with no `v` prefix.
+- Release tags are created as `v<version>` by the workflow.
+- Do not change archive version formatting unless release artifact names are
+  part of the task.

--- a/docs/mdk/project-map.md
+++ b/docs/mdk/project-map.md
@@ -1,0 +1,160 @@
+# Project Map
+
+This file maps repository locations to responsibilities.
+
+## Root
+
+`settings.gradle.kts`
+
+- Includes every active Gradle subproject.
+- Defines `ciBuildProjectNames` as all children except `common` and `*-common`.
+- Controls which loader projects enter the build and release matrices.
+
+`build.gradle.kts`
+
+- Applies loader Gradle plugins at the root with `apply false`.
+- Registers `writeCiBuildMatrix`.
+- Reads `version.txt` into `modVersion`.
+- Sets common subproject group, version, repositories, Java compile encoding,
+  archive version, and IDEA behavior.
+
+`gradle.properties`
+
+- Global mod metadata and Fabric entrypoint defaults.
+
+`version.txt`
+
+- Single release version used by all subprojects.
+
+`gradle/libs.versions.toml`
+
+- Shared plugin and dependency aliases.
+
+## Shared Code
+
+`common/src/main`
+
+- Cross-version Java used by all loaders and Minecraft versions.
+
+`common/src/config`
+
+- Cross-version config model and declaration code.
+
+`<mc>-common/src/main`
+
+- Java shared by all loaders for one Minecraft version.
+- Use this for API differences tied to a Minecraft version.
+
+`<mc>-common/src/config`
+
+- Version-specific config support.
+
+## Loader Projects
+
+`<mc>-fabric`
+
+- Fabric loader entrypoint and Fabric-specific integration.
+- Uses either `fabric-loom-mod-conventions` or
+  `fabric-loom-remap-mod-conventions`.
+- Usually applies `fabric-api-conventions` and `fabric-config-conventions`.
+
+`<mc>-forge`
+
+- Legacy Forge entrypoint, resources, mixin config, templates, and runtime deps.
+- Uses `legacyforge-mod-conventions`.
+- Applies `legacyforge-config-conventions` when config code is included.
+
+`<mc>-neo`
+
+- NeoForge entrypoint, resources, templates, and runtime deps.
+- Uses `neoforge-mod-conventions`.
+- Applies `neoforge-config-conventions` when config code is included.
+
+## Source Sets
+
+`src/main/java`
+
+- Loader-specific main code.
+- Loader entrypoints live here unless a convention says otherwise.
+
+`src/client/java`
+
+- Fabric client source set, including Fabric `ModClient`.
+
+`src/config/java`
+
+- Config implementation source set.
+
+`src/configClient/java`
+
+- Client config UI source set.
+
+`src/main/resources`
+
+- Static loader resources, such as mixin JSON files.
+
+`src/main/templates`
+
+- Loader metadata templates.
+- Fabric: `fabric.mod.json`.
+- Legacy Forge: `META-INF/mods.toml`.
+- NeoForge: `META-INF/neoforge.mods.toml`.
+
+`src/generated/resources`
+
+- Generated data resources for Forge and NeoForge data runs.
+
+## buildSrc
+
+`buildSrc/src/main/kotlin/*conventions.gradle.kts`
+
+- Precompiled Gradle convention plugins.
+
+`common-config-conventions`
+
+- Adds `src/config` to `common` and packages its output.
+
+`legacyforge-common-conventions`, `neoforge-common-conventions`
+
+- Configure one-version common projects for Legacy Forge or NeoForge tooling.
+
+`legacyforge-mod-conventions`, `neoforge-mod-conventions`
+
+- Configure runs, metadata generation, Java toolchain, archives, and jar
+  contents for Forge and NeoForge.
+
+`fabric-mod-conventions`
+
+- Configures Fabric metadata generation, Java toolchain, archives, and jar
+  contents.
+
+`fabric-loom-mod-conventions`, `fabric-loom-remap-mod-conventions`
+
+- Configure Loom, split client source sets, Minecraft dependencies, mappings,
+  and shared source sets.
+
+`fabric-api-conventions`
+
+- Adds Fabric API dependency and game test setup where supported.
+
+`*-config-conventions`
+
+- Wire `src/config` and `src/configClient` into classpaths and jars.
+
+`net/meatwo310/mdk/build`
+
+- Kotlin helpers for source sets, runtime mod staging, Fabric metadata, version
+  support, and version catalog access.
+
+## CI And Release
+
+`.github/workflows/build.yml`
+
+- Detects platform projects with `writeCiBuildMatrix`.
+- Uploads jars and runtime mod jars, then runs game/server/runtime tests.
+
+`.github/workflows/release.yml`
+
+- Manually bumps or keeps `version.txt`.
+- Builds all platform projects from the CI matrix.
+- Collects jars, generates release notes, tags, and publishes a GitHub Release.

--- a/docs/mdk/workflow.md
+++ b/docs/mdk/workflow.md
@@ -1,0 +1,130 @@
+# Standard Workflow
+
+Use this flow for normal code, build, and template changes.
+
+## 1. Identify Scope
+
+Before editing, answer these questions from the repository:
+
+- Which Minecraft versions are affected?
+- Which loaders are affected: Fabric, Legacy Forge, NeoForge, or all?
+- Is the change shared across all versions, one Minecraft version, or one
+  loader project?
+- Does it touch only runtime code, or also config, metadata, build logic, CI, or
+  release behavior?
+
+Check `settings.gradle.kts` for the real project list. Directory names that are
+not included are not build participants.
+
+## 2. Choose The Owning Location
+
+Use the narrowest correct location:
+
+- Put cross-version shared Java in `common/src/main`.
+- Put cross-version shared config declarations in `common/src/config`.
+- Put one-version shared Java in `<mc>-common/src/main`.
+- Put one-version shared config helpers in `<mc>-common/src/config`.
+- Put loader startup code in `<mc>-fabric`, `<mc>-forge`, or `<mc>-neo`.
+- Put Fabric client-only code in `<mc>-fabric/src/client`.
+- Put loader client config UI code in `src/configClient` where that project has
+  the source set.
+- Put generated metadata shape in `src/main/templates`.
+- Put build behavior in `buildSrc/src/main/kotlin` unless it is truly unique to
+  one subproject.
+
+## 3. Inspect Existing Patterns
+
+Search before changing:
+
+```bash
+rg "symbol_or_property_name"
+rg --files '<mc>-fabric' '<mc>-forge' '<mc>-neo' '<mc>-common' common
+```
+
+For repeated version/loader files, inspect at least one older Forge project, one
+Fabric project, and one NeoForge project when applicable. Keep names, packages,
+and source set layout consistent with nearby examples.
+
+## 4. Edit
+
+Keep edits small and paired:
+
+- If code references a shared API, update every version-specific implementation
+  that must compile against it.
+- If metadata values change, prefer `gradle.properties` over template rewrites.
+- If metadata structure changes, update the relevant template and convention
+  plugin inputs together.
+- If adding dependencies, update the relevant subproject `build.gradle.kts` and
+  version property or `libs.versions.toml` entry.
+- If adding a project, update `settings.gradle.kts` and make sure the project
+  name follows `<mc>-<loader>` or `<mc>-common`.
+
+Do not edit generated build outputs.
+
+## 5. Verify Locally
+
+Run the narrowest build first:
+
+```bash
+./gradlew :<project>:build
+```
+
+Examples:
+
+```bash
+./gradlew :1.20.1-fabric:build
+./gradlew :1.20.1-forge:build
+./gradlew :26.1-neo:build
+```
+
+For shared changes, build representative downstream projects:
+
+```bash
+./gradlew :1.18.2-forge:build :1.20.1-fabric:build :26.1-neo:build
+```
+
+For CI matrix or project inclusion changes:
+
+```bash
+./gradlew --configuration-cache --no-daemon writeCiBuildMatrix
+cat build/ci/build-matrix.json
+```
+
+For Forge or NeoForge game test server support:
+
+```bash
+./gradlew :<forge-or-neo-project>:runGameTestServer
+```
+
+For older projects that do not support `runGameTestServer`, use a server smoke
+test:
+
+```bash
+mkdir -p <project>/run
+printf 'eula=true\n' > <project>/run/eula.txt
+echo stop | ./gradlew :<project>:runServer
+```
+
+## 6. Match CI Expectations
+
+The GitHub `Build` workflow derives platform projects from
+`settings.gradle.kts`, excluding `common` and `*-common`. A platform project
+must have:
+
+- a valid `minecraftVersion`;
+- a loader suffix of `fabric`, `forge`, or `neo`;
+- a matching `<minecraftVersion>-common` project;
+- a numeric `javaVersion` when set;
+- buildable jars under `<project>/build/libs`;
+- optional runtime jars staged by `collectRuntimeMods`.
+
+Run `writeCiBuildMatrix` whenever those assumptions might have changed.
+
+## 7. Final Check
+
+Before handing off:
+
+- Run `git status --short`.
+- Confirm only intended files changed.
+- State which verification commands passed or could not be run.
+- Mention any project/version/loader combinations that were not verified.


### PR DESCRIPTION
## Summary
- Add compact LLM-oriented documentation under `docs/mdk/` for repository navigation, workflow, project layout, and change recipes.
- Strengthen the setup guidance to trim unused `settings.gradle.kts` projects before IDEA/Gradle import.
- Fix the specific build example to use the included `26.1.2-neo` project.

## Validation
- Ran `git diff --cached --check` before committing.
- Did not run Gradle because this PR only changes documentation.