### PR TITLE
[codex] 共通コンフィグエントリの書き込みを追加

### DIFF
--- a/1.18.2-forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.18.2-forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -53,39 +53,50 @@ public final class VersionedConfigSpec {
         }
 
         @Override
-        public Supplier<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Boolean> defineBoolean(String key, boolean defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<Boolean> defineBoolean(String key, boolean defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public Supplier<String> defineString(String key, String defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<String> defineString(String key, String defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public <T> Supplier<? extends List<? extends T>> defineList(
+        public <T> ConfigEntryBinding<List<T>> defineList(
                 String key, List<T> defaultValue, Supplier<T> newElementSupplier, Predicate<Object> elementValidator) {
-            return builder.defineList(key, defaultValue, elementValidator);
+            return bindListValue(builder.defineList(key, defaultValue, elementValidator));
         }
 
         @Override
-        public <E extends Enum<E>> Supplier<E> defineEnum(String key, E defaultValue) {
-            return builder.defineEnum(key, defaultValue);
+        public <E extends Enum<E>> ConfigEntryBinding<E> defineEnum(String key, E defaultValue) {
+            return bindValue(builder.defineEnum(key, defaultValue));
+        }
+
+        private static <T> ConfigEntryBinding<T> bindValue(ForgeConfigSpec.ConfigValue<T> value) {
+            return ConfigEntryBinding.of(value::get, value::set, value::save);
+        }
+
+        private static <T> ConfigEntryBinding<List<T>> bindListValue(ForgeConfigSpec.ConfigValue<List<? extends T>> value) {
+            return ConfigEntryBinding.of(
+                    () -> List.copyOf(value.get()),
+                    nextValue -> value.set(List.copyOf(nextValue)),
+                    value::save);
         }
     }
 }

--- a/1.19.2-forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.19.2-forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -53,39 +53,50 @@ public final class VersionedConfigSpec {
         }
 
         @Override
-        public Supplier<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Boolean> defineBoolean(String key, boolean defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<Boolean> defineBoolean(String key, boolean defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public Supplier<String> defineString(String key, String defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<String> defineString(String key, String defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public <T> Supplier<? extends List<? extends T>> defineList(
+        public <T> ConfigEntryBinding<List<T>> defineList(
                 String key, List<T> defaultValue, Supplier<T> newElementSupplier, Predicate<Object> elementValidator) {
-            return builder.defineList(key, defaultValue, elementValidator);
+            return bindListValue(builder.defineList(key, defaultValue, elementValidator));
         }
 
         @Override
-        public <E extends Enum<E>> Supplier<E> defineEnum(String key, E defaultValue) {
-            return builder.defineEnum(key, defaultValue);
+        public <E extends Enum<E>> ConfigEntryBinding<E> defineEnum(String key, E defaultValue) {
+            return bindValue(builder.defineEnum(key, defaultValue));
+        }
+
+        private static <T> ConfigEntryBinding<T> bindValue(ForgeConfigSpec.ConfigValue<T> value) {
+            return ConfigEntryBinding.of(value::get, value::set, value::save);
+        }
+
+        private static <T> ConfigEntryBinding<List<T>> bindListValue(ForgeConfigSpec.ConfigValue<List<? extends T>> value) {
+            return ConfigEntryBinding.of(
+                    () -> List.copyOf(value.get()),
+                    nextValue -> value.set(List.copyOf(nextValue)),
+                    value::save);
         }
     }
 }

--- a/1.20.1-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.20.1-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -53,39 +53,50 @@ public final class VersionedConfigSpec {
         }
 
         @Override
-        public Supplier<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Boolean> defineBoolean(String key, boolean defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<Boolean> defineBoolean(String key, boolean defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public Supplier<String> defineString(String key, String defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<String> defineString(String key, String defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public <T> Supplier<? extends List<? extends T>> defineList(
+        public <T> ConfigEntryBinding<List<T>> defineList(
                 String key, List<T> defaultValue, Supplier<T> newElementSupplier, Predicate<Object> elementValidator) {
-            return builder.defineList(key, defaultValue, elementValidator);
+            return bindListValue(builder.defineList(key, defaultValue, elementValidator));
         }
 
         @Override
-        public <E extends Enum<E>> Supplier<E> defineEnum(String key, E defaultValue) {
-            return builder.defineEnum(key, defaultValue);
+        public <E extends Enum<E>> ConfigEntryBinding<E> defineEnum(String key, E defaultValue) {
+            return bindValue(builder.defineEnum(key, defaultValue));
+        }
+
+        private static <T> ConfigEntryBinding<T> bindValue(ForgeConfigSpec.ConfigValue<T> value) {
+            return ConfigEntryBinding.of(value::get, value::set, value::save);
+        }
+
+        private static <T> ConfigEntryBinding<List<T>> bindListValue(ForgeConfigSpec.ConfigValue<List<? extends T>> value) {
+            return ConfigEntryBinding.of(
+                    () -> List.copyOf(value.get()),
+                    nextValue -> value.set(List.copyOf(nextValue)),
+                    value::save);
         }
     }
 }

--- a/1.21.1-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.21.1-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -53,39 +53,50 @@ public final class VersionedConfigSpec {
         }
 
         @Override
-        public Supplier<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Boolean> defineBoolean(String key, boolean defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<Boolean> defineBoolean(String key, boolean defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public Supplier<String> defineString(String key, String defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<String> defineString(String key, String defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public <T> Supplier<? extends List<? extends T>> defineList(
+        public <T> ConfigEntryBinding<List<T>> defineList(
                 String key, List<T> defaultValue, Supplier<T> newElementSupplier, Predicate<Object> elementValidator) {
-            return builder.defineList(key, defaultValue, newElementSupplier, elementValidator);
+            return bindListValue(builder.defineList(key, defaultValue, newElementSupplier, elementValidator));
         }
 
         @Override
-        public <E extends Enum<E>> Supplier<E> defineEnum(String key, E defaultValue) {
-            return builder.defineEnum(key, defaultValue);
+        public <E extends Enum<E>> ConfigEntryBinding<E> defineEnum(String key, E defaultValue) {
+            return bindValue(builder.defineEnum(key, defaultValue));
+        }
+
+        private static <T> ConfigEntryBinding<T> bindValue(ModConfigSpec.ConfigValue<T> value) {
+            return ConfigEntryBinding.of(value::get, value::set, value::save);
+        }
+
+        private static <T> ConfigEntryBinding<List<T>> bindListValue(ModConfigSpec.ConfigValue<List<? extends T>> value) {
+            return ConfigEntryBinding.of(
+                    () -> List.copyOf(value.get()),
+                    nextValue -> value.set(List.copyOf(nextValue)),
+                    value::save);
         }
     }
 }

--- a/1.21.11-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.21.11-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -53,39 +53,50 @@ public final class VersionedConfigSpec {
         }
 
         @Override
-        public Supplier<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Boolean> defineBoolean(String key, boolean defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<Boolean> defineBoolean(String key, boolean defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public Supplier<String> defineString(String key, String defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<String> defineString(String key, String defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public <T> Supplier<? extends List<? extends T>> defineList(
+        public <T> ConfigEntryBinding<List<T>> defineList(
                 String key, List<T> defaultValue, Supplier<T> newElementSupplier, Predicate<Object> elementValidator) {
-            return builder.defineList(key, defaultValue, newElementSupplier, elementValidator);
+            return bindListValue(builder.defineList(key, defaultValue, newElementSupplier, elementValidator));
         }
 
         @Override
-        public <E extends Enum<E>> Supplier<E> defineEnum(String key, E defaultValue) {
-            return builder.defineEnum(key, defaultValue);
+        public <E extends Enum<E>> ConfigEntryBinding<E> defineEnum(String key, E defaultValue) {
+            return bindValue(builder.defineEnum(key, defaultValue));
+        }
+
+        private static <T> ConfigEntryBinding<T> bindValue(ModConfigSpec.ConfigValue<T> value) {
+            return ConfigEntryBinding.of(value::get, value::set, value::save);
+        }
+
+        private static <T> ConfigEntryBinding<List<T>> bindListValue(ModConfigSpec.ConfigValue<List<? extends T>> value) {
+            return ConfigEntryBinding.of(
+                    () -> List.copyOf(value.get()),
+                    nextValue -> value.set(List.copyOf(nextValue)),
+                    value::save);
         }
     }
 }

--- a/1.21.8-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.21.8-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -53,39 +53,50 @@ public final class VersionedConfigSpec {
         }
 
         @Override
-        public Supplier<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Boolean> defineBoolean(String key, boolean defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<Boolean> defineBoolean(String key, boolean defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public Supplier<String> defineString(String key, String defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<String> defineString(String key, String defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public <T> Supplier<? extends List<? extends T>> defineList(
+        public <T> ConfigEntryBinding<List<T>> defineList(
                 String key, List<T> defaultValue, Supplier<T> newElementSupplier, Predicate<Object> elementValidator) {
-            return builder.defineList(key, defaultValue, newElementSupplier, elementValidator);
+            return bindListValue(builder.defineList(key, defaultValue, newElementSupplier, elementValidator));
         }
 
         @Override
-        public <E extends Enum<E>> Supplier<E> defineEnum(String key, E defaultValue) {
-            return builder.defineEnum(key, defaultValue);
+        public <E extends Enum<E>> ConfigEntryBinding<E> defineEnum(String key, E defaultValue) {
+            return bindValue(builder.defineEnum(key, defaultValue));
+        }
+
+        private static <T> ConfigEntryBinding<T> bindValue(ModConfigSpec.ConfigValue<T> value) {
+            return ConfigEntryBinding.of(value::get, value::set, value::save);
+        }
+
+        private static <T> ConfigEntryBinding<List<T>> bindListValue(ModConfigSpec.ConfigValue<List<? extends T>> value) {
+            return ConfigEntryBinding.of(
+                    () -> List.copyOf(value.get()),
+                    nextValue -> value.set(List.copyOf(nextValue)),
+                    value::save);
         }
     }
 }

--- a/26.1-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/26.1-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -53,39 +53,50 @@ public final class VersionedConfigSpec {
         }
 
         @Override
-        public Supplier<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Boolean> defineBoolean(String key, boolean defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<Boolean> defineBoolean(String key, boolean defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public Supplier<String> defineString(String key, String defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<String> defineString(String key, String defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public <T> Supplier<? extends List<? extends T>> defineList(
+        public <T> ConfigEntryBinding<List<T>> defineList(
                 String key, List<T> defaultValue, Supplier<T> newElementSupplier, Predicate<Object> elementValidator) {
-            return builder.defineList(key, defaultValue, newElementSupplier, elementValidator);
+            return bindListValue(builder.defineList(key, defaultValue, newElementSupplier, elementValidator));
         }
 
         @Override
-        public <E extends Enum<E>> Supplier<E> defineEnum(String key, E defaultValue) {
-            return builder.defineEnum(key, defaultValue);
+        public <E extends Enum<E>> ConfigEntryBinding<E> defineEnum(String key, E defaultValue) {
+            return bindValue(builder.defineEnum(key, defaultValue));
+        }
+
+        private static <T> ConfigEntryBinding<T> bindValue(ModConfigSpec.ConfigValue<T> value) {
+            return ConfigEntryBinding.of(value::get, value::set, value::save);
+        }
+
+        private static <T> ConfigEntryBinding<List<T>> bindListValue(ModConfigSpec.ConfigValue<List<? extends T>> value) {
+            return ConfigEntryBinding.of(
+                    () -> List.copyOf(value.get()),
+                    nextValue -> value.set(List.copyOf(nextValue)),
+                    value::save);
         }
     }
 }

--- a/26.1.2-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/26.1.2-common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -53,39 +53,50 @@ public final class VersionedConfigSpec {
         }
 
         @Override
-        public Supplier<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Long> defineLongInRange(String key, long defaultValue, long min, long max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
-            return builder.defineInRange(key, defaultValue, min, max);
+        public ConfigEntryBinding<Double> defineDoubleInRange(String key, double defaultValue, double min, double max) {
+            return bindValue(builder.defineInRange(key, defaultValue, min, max));
         }
 
         @Override
-        public Supplier<Boolean> defineBoolean(String key, boolean defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<Boolean> defineBoolean(String key, boolean defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public Supplier<String> defineString(String key, String defaultValue) {
-            return builder.define(key, defaultValue);
+        public ConfigEntryBinding<String> defineString(String key, String defaultValue) {
+            return bindValue(builder.define(key, defaultValue));
         }
 
         @Override
-        public <T> Supplier<? extends List<? extends T>> defineList(
+        public <T> ConfigEntryBinding<List<T>> defineList(
                 String key, List<T> defaultValue, Supplier<T> newElementSupplier, Predicate<Object> elementValidator) {
-            return builder.defineList(key, defaultValue, newElementSupplier, elementValidator);
+            return bindListValue(builder.defineList(key, defaultValue, newElementSupplier, elementValidator));
         }
 
         @Override
-        public <E extends Enum<E>> Supplier<E> defineEnum(String key, E defaultValue) {
-            return builder.defineEnum(key, defaultValue);
+        public <E extends Enum<E>> ConfigEntryBinding<E> defineEnum(String key, E defaultValue) {
+            return bindValue(builder.defineEnum(key, defaultValue));
+        }
+
+        private static <T> ConfigEntryBinding<T> bindValue(ModConfigSpec.ConfigValue<T> value) {
+            return ConfigEntryBinding.of(value::get, value::set, value::save);
+        }
+
+        private static <T> ConfigEntryBinding<List<T>> bindListValue(ModConfigSpec.ConfigValue<List<? extends T>> value) {
+            return ConfigEntryBinding.of(
+                    () -> List.copyOf(value.get()),
+                    nextValue -> value.set(List.copyOf(nextValue)),
+                    value::save);
         }
     }
 }

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntry.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntry.java
@@ -6,13 +6,13 @@ import java.util.function.*;
 public abstract class ConfigEntry<T> implements Supplier<T>, ConfigElement {
     private final String key, comment;
     private final T defaultValue;
-    private Supplier<T> value;
+    private ConfigEntryBinding<T> value;
 
     protected ConfigEntry(String key, String comment, T defaultValue) {
         this.key = key;
         this.comment = comment;
         this.defaultValue = defaultValue;
-        this.value = () -> defaultValue;
+        this.value = ConfigEntryBinding.unbound(defaultValue);
     }
 
     public String key() {
@@ -27,8 +27,20 @@ public abstract class ConfigEntry<T> implements Supplier<T>, ConfigElement {
         return value.get();
     }
 
-    public void bind(Supplier<T> supplier) {
-        this.value = supplier;
+    public void set(T value) {
+        this.value.set(value);
+    }
+
+    public void flush() {
+        value.flush();
+    }
+
+    public void setAndFlush(T value) {
+        this.value.setAndFlush(value);
+    }
+
+    public void bind(ConfigEntryBinding<T> binding) {
+        this.value = binding;
     }
 
     public T defaultValue() {
@@ -63,7 +75,7 @@ public abstract class ConfigEntry<T> implements Supplier<T>, ConfigElement {
         }
 
         public void bind(IntSupplier supplier) {
-            super.bind(supplier::getAsInt);
+            super.bind(ConfigEntryBinding.readOnly(supplier::getAsInt));
         }
 
         @Override
@@ -83,7 +95,7 @@ public abstract class ConfigEntry<T> implements Supplier<T>, ConfigElement {
         }
 
         public void bind(LongSupplier supplier) {
-            super.bind(supplier::getAsLong);
+            super.bind(ConfigEntryBinding.readOnly(supplier::getAsLong));
         }
 
         @Override
@@ -103,7 +115,7 @@ public abstract class ConfigEntry<T> implements Supplier<T>, ConfigElement {
         }
 
         public void bind(DoubleSupplier supplier) {
-            super.bind(supplier::getAsDouble);
+            super.bind(ConfigEntryBinding.readOnly(supplier::getAsDouble));
         }
 
         @Override
@@ -123,7 +135,7 @@ public abstract class ConfigEntry<T> implements Supplier<T>, ConfigElement {
         }
 
         public void bind(BooleanSupplier supplier) {
-            super.bind(supplier::getAsBoolean);
+            super.bind(ConfigEntryBinding.readOnly(supplier::getAsBoolean));
         }
 
         @Override

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBinder.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBinder.java
@@ -49,7 +49,7 @@ public final class ConfigEntryBinder implements ConfigVisitor {
         adapter.comment(entry.comment());
         var value = adapter.defineList(
                 entry.key(), entry.defaultValue(), entry.newElementSupplier(), entry.elementValidator());
-        entry.bind(() -> List.copyOf(value.get()));
+        entry.bind(value);
     }
 
     @Override
@@ -76,19 +76,19 @@ public final class ConfigEntryBinder implements ConfigVisitor {
 
         void pop();
 
-        Supplier<Integer> defineIntInRange(String key, int defaultValue, int min, int max);
+        ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max);
 
-        Supplier<Long> defineLongInRange(String key, long defaultValue, long min, long max);
+        ConfigEntryBinding<Long> defineLongInRange(String key, long defaultValue, long min, long max);
 
-        Supplier<Double> defineDoubleInRange(String key, double defaultValue, double min, double max);
+        ConfigEntryBinding<Double> defineDoubleInRange(String key, double defaultValue, double min, double max);
 
-        Supplier<Boolean> defineBoolean(String key, boolean defaultValue);
+        ConfigEntryBinding<Boolean> defineBoolean(String key, boolean defaultValue);
 
-        Supplier<String> defineString(String key, String defaultValue);
+        ConfigEntryBinding<String> defineString(String key, String defaultValue);
 
-        <T> Supplier<? extends List<? extends T>> defineList(
+        <T> ConfigEntryBinding<List<T>> defineList(
                 String key, List<T> defaultValue, Supplier<T> newElementSupplier, Predicate<Object> elementValidator);
 
-        <E extends Enum<E>> Supplier<E> defineEnum(String key, E defaultValue);
+        <E extends Enum<E>> ConfigEntryBinding<E> defineEnum(String key, E defaultValue);
     }
 }

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBinding.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBinding.java
@@ -1,0 +1,72 @@
+package net.meatwo310.examplemod.mdk.config;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public interface ConfigEntryBinding<T> extends Supplier<T> {
+    void set(T value);
+
+    void flush();
+
+    default void setAndFlush(T value) {
+        set(value);
+        flush();
+    }
+
+    static <T> ConfigEntryBinding<T> of(Supplier<T> getter, Consumer<T> setter, Runnable flusher) {
+        return new ConfigEntryBinding<>() {
+            @Override
+            public T get() {
+                return getter.get();
+            }
+
+            @Override
+            public void set(T value) {
+                setter.accept(value);
+            }
+
+            @Override
+            public void flush() {
+                flusher.run();
+            }
+        };
+    }
+
+    static <T> ConfigEntryBinding<T> readOnly(Supplier<T> getter) {
+        return new ConfigEntryBinding<>() {
+            @Override
+            public T get() {
+                return getter.get();
+            }
+
+            @Override
+            public void set(T value) {
+                throw new UnsupportedOperationException("Config entry binding is read-only");
+            }
+
+            @Override
+            public void flush() {
+                throw new UnsupportedOperationException("Config entry binding is read-only");
+            }
+        };
+    }
+
+    static <T> ConfigEntryBinding<T> unbound(T defaultValue) {
+        return new ConfigEntryBinding<>() {
+            @Override
+            public T get() {
+                return defaultValue;
+            }
+
+            @Override
+            public void set(T value) {
+                throw new IllegalStateException("Config entry is not bound");
+            }
+
+            @Override
+            public void flush() {
+                throw new IllegalStateException("Config entry is not bound");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Add a loader-neutral `ConfigEntryBinding` abstraction for config entry get/set/flush operations.
- Expose `set`, `flush`, and `setAndFlush` from shared `ConfigEntry` instances while preserving existing `Supplier`-style reads.
- Wrap Forge and NeoForge `ConfigValue` instances in every supported `VersionedConfigSpec` so shared config code can update and persist values.

## Why

The shared config model previously stored only `Supplier<T>` bindings, so common code could read config entries but could not reach the underlying loader `ConfigValue#set` or `save` APIs. This change keeps the shared declarations loader-neutral while preserving write and flush support.

## Validation

- `./gradlew --configuration-cache --no-daemon :common:compileConfigJava`
- `./gradlew --configuration-cache --no-daemon build`