### PR TITLE
[codex] runServer smoke testで正常終了ログを確認

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,9 +97,12 @@ jobs:
         if: ${{ matrix.run_server }}
         timeout-minutes: 10
         run: |
+          set -o pipefail
           mkdir -p "${{ matrix.subproject }}/run"
           printf 'eula=true\n' > "${{ matrix.subproject }}/run/eula.txt"
-          echo stop | ./gradlew ":${{ matrix.subproject }}:runServer"
+          server_log="${RUNNER_TEMP}/runServer-${{ matrix.subproject }}.log"
+          printf 'stop\n' | ./gradlew ":${{ matrix.subproject }}:runServer" 2>&1 | tee "$server_log"
+          grep -E '\[Server thread/INFO\].*Stopping server$' "$server_log"
 
       - name: Setup runtime JDK
         uses: actions/setup-java@v5

--- a/docs/README.md
+++ b/docs/README.md
@@ -299,7 +299,7 @@ PlatformConfigRegistrar.registerAll(modContainer, VersionedConfigSpec.bindAll(co
 
 ## GitHub Actions
 
-The build workflow detects subprojects from `settings.gradle.kts`, builds each one independently, uploads loader artifacts, runs the available server or game-test smoke checks, and then launches a headless client runtime test with the produced jars. Note: Fabric Game Tests are configured through Fabric Loom and run as part of the Fabric `build` task.
+The build workflow detects subprojects from `settings.gradle.kts`, builds each one independently, uploads loader artifacts, runs the available server or game-test smoke checks, verifies the `runServer` shutdown log when that smoke test is used, and then launches a headless client runtime test with the produced jars. Note: Fabric Game Tests are configured through Fabric Loom and run as part of the Fabric `build` task.
 
 ### Release CI
 

--- a/docs/mdk/README.md
+++ b/docs/mdk/README.md
@@ -79,7 +79,7 @@ The `Build` workflow ignores docs-only changes. For code changes, it:
 - builds every loader project detected from `settings.gradle.kts`;
 - uploads each loader project's `build/libs` and `build/ciRuntimeMods`;
 - runs Forge/NeoForge game tests when supported;
-- otherwise starts a server smoke test;
+- otherwise starts a server smoke test and verifies the shutdown log;
 - runs `headlesshq/mc-runtime-test` against the built jars.
 
 The `Release` workflow is manual. It can bump `version.txt`, build all platform

--- a/docs/mdk/workflow.md
+++ b/docs/mdk/workflow.md
@@ -104,7 +104,8 @@ test:
 ```bash
 mkdir -p <project>/run
 printf 'eula=true\n' > <project>/run/eula.txt
-echo stop | ./gradlew :<project>:runServer
+printf 'stop\n' | ./gradlew :<project>:runServer 2>&1 | tee runServer.log
+grep -E '\[Server thread/INFO\].*Stopping server$' runServer.log
 ```
 
 ## 6. Match CI Expectations


### PR DESCRIPTION
## Summary
- Capture the `runServer` smoke test output in CI and require the shutdown log line.
- Keep Gradle failures visible by enabling `pipefail` around the `tee` pipeline.
- Update docs to describe the shutdown-log check used by the server smoke test.

## Why
Some older run configurations can exit successfully even when the server did not actually complete the expected shutdown path. Checking for `[Server thread/INFO] ... Stopping server` makes the smoke test assert the normal shutdown signal explicitly.

## Validation
- `git diff --check`
- YAML parse check for `.github/workflows/build.yml`