### PR TITLE
[codex] config出力をdev実行に含める

### DIFF
--- a/buildSrc/src/main/kotlin/net/meatwo310/mdk/build/ConfigSourceSets.kt
+++ b/buildSrc/src/main/kotlin/net/meatwo310/mdk/build/ConfigSourceSets.kt
@@ -49,6 +49,7 @@ fun Project.addConfigOutputTo(sourceSetName: String, vararg configSourceSets: So
         for (configSourceSet in configSourceSets) {
             target.compileClasspath += configSourceSet.output
             target.runtimeClasspath += configSourceSet.output
+            target.output.dir(configSourceSet.output)
         }
     }
 }


### PR DESCRIPTION
## Summary

- 共通 config SourceSet の classes/resources 出力を、対象 SourceSet の output にも追加します。
- Forge/NeoForge の dev run が `sourceSet(main)` 経由で config クラスを解決できるようにします。

## Root Cause

CI の `Run Server` で Forge/NeoForge 系が `NoClassDefFoundError: net/meatwo310/examplemod/config/ModConfigs` により失敗していました。config 出力は jar へ同梱されていましたが、moddev の `runServer` は jar ではなく SourceSet output を mod 座標として使うため、共通 config クラスが実行時に見えていませんでした。

## Validation

- `./gradlew --configuration-cache --no-daemon :buildSrc:compileKotlin`
- `./gradlew --configuration-cache --no-daemon :1.18.2-forge:runServer`
- `./gradlew --configuration-cache --no-daemon :1.20.1-forge:runServer`
- `./gradlew --configuration-cache --no-daemon :1.21.1-neo:runServer`
- `./gradlew --configuration-cache --no-daemon :1.20.1-forge:jar :1.21.1-neo:jar :1.20.1-fabric:jar`
- `./gradlew --configuration-cache --no-daemon writeCiBuildMatrix`