### PR TITLE
[codex] ciRuntimeModsをアーティファクトから除外

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,9 +82,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          path: |
-            ${{ matrix.subproject }}/build/libs/
-            ${{ matrix.subproject }}/build/ciRuntimeMods/
+          path: ${{ matrix.subproject }}/build/libs/
           name: artifact-${{ matrix.subproject }}
 
       # Fabric Game Tests are run implicitly by the build task.

--- a/docs/mdk/README.md
+++ b/docs/mdk/README.md
@@ -77,7 +77,7 @@ The `Build` workflow ignores docs-only changes. For code changes, it:
 
 - runs `./gradlew --configuration-cache --no-daemon writeCiBuildMatrix`;
 - builds every loader project detected from `settings.gradle.kts`;
-- uploads each loader project's `build/libs` and `build/ciRuntimeMods`;
+- uploads each loader project's `build/libs`;
 - runs Forge/NeoForge game tests when supported;
 - otherwise starts a server smoke test and verifies the shutdown log;
 - runs `headlesshq/mc-runtime-test` against the built jars.


### PR DESCRIPTION
## 概要

- Build workflow の `actions/upload-artifact` 対象を `build/libs/` のみに戻します。
- `ciRuntimeMods` は引き続き同一ジョブ内のランタイムテストで `run/mods` にコピーします。
- CI説明ドキュメントから `build/ciRuntimeMods` のアップロード記述を削除します。

## 背景

`ciRuntimeMods` はGitHub Actionsのランタイムテスト用に追加Mod jarをステージするためのディレクトリです。アーティファクトに含める必要はなく、含めると配布対象ではない補助Modが `artifact-<subproject>` に混ざります。

履歴確認では、`ciRuntimeMods` 名でのアップロードは 2026-06-12 の `runtimeMods` からの名称変更で入り、挙動自体は 2026-05-20 の `runtimeMods` 導入時点から存在していました。

## 確認

- `./gradlew --configuration-cache --no-daemon writeCiBuildMatrix`