### PR TITLE
[codex] Loom 1.17.11 に更新し実行構成で Gradle タスクを優先

### DIFF
--- a/buildSrc/src/main/kotlin/fabric-loom-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-loom-mod-conventions.gradle.kts
@@ -26,6 +26,7 @@ loom {
 
     runs.configureEach {
         ideConfigGenerated(true)
+        preferGradleTask.set(true)
         if (name == "gameTest") {
             vmArg("-Dfabric.log.level=debug")
         }

--- a/buildSrc/src/main/kotlin/fabric-loom-remap-mod-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fabric-loom-remap-mod-conventions.gradle.kts
@@ -31,6 +31,7 @@ loom {
 
     runs.configureEach {
         ideConfigGenerated(true)
+        preferGradleTask.set(true)
         if (name == "gameTest") {
             vmArg("-Dfabric.log.level=debug")
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-fabric-loom = "1.16.2"
+fabric-loom = "1.17.11"
 fabric-loader = "0.19.2"
 mixin = "0.8.7"
 neoforged-moddev = "2.0.141"


### PR DESCRIPTION
## Summary
- Fabric Loom を 1.16.2 から 1.17.11 に更新しました。
- Fabric の run configurations で `preferGradleTask` を有効化し、IDE 実行構成が Gradle の run task を優先するようにしました。

## Validation
- `./gradlew help`

fixes: #16