### PR TITLE
[codex] 26.2 の MC runtime test を無効化

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,7 @@ jobs:
           grep -E '\[Server thread/INFO\].*Stopping server$' "$server_log"
 
       - name: Setup runtime JDK
+        if: ${{ matrix.run_mc_runtime_test }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
@@ -111,6 +112,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Stage mod for runtime test client
+        if: ${{ matrix.run_mc_runtime_test }}
         run: |
           mkdir -p run/mods
           find "${{ matrix.subproject }}/build/libs" -maxdepth 1 -type f -name '*.jar' \
@@ -126,6 +128,7 @@ jobs:
           ls -la run/mods
 
       - name: Run MC runtime test client
+        if: ${{ matrix.run_mc_runtime_test }}
         timeout-minutes: 10
         uses: headlesshq/mc-runtime-test@4.4.0
         with:

--- a/26.2-fabric/gradle.properties
+++ b/26.2-fabric/gradle.properties
@@ -2,5 +2,6 @@ minecraftVersion=26.2
 fabricApiVersion=0.152.1+26.2
 javaVersion=25
 forgeConfigApiPortVersion=26.2.0
+ciMcRuntimeTest=false
 
 modmenuVersion=20.0.0-beta.2

--- a/26.2-neo/gradle.properties
+++ b/26.2-neo/gradle.properties
@@ -3,3 +3,4 @@ minecraftVersionRange=[26.2]
 neoVersion=26.2.0.1-beta
 javaVersion=25
 neoDataRun=clientData
+ciMcRuntimeTest=false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,10 @@ tasks.register("writeCiBuildMatrix") {
             ?.toString()
             ?.substringBefore("+")
             ?: "none"
+        val runMcRuntimeTest = targetProject.findProperty("ciMcRuntimeTest")
+            ?.toString()
+            ?.toBooleanStrictOrNull()
+            ?: true
         val modloader = if (loader == "neo") "neoforge" else loader
         val mcRuntimeTest = when (loader) {
             "forge" -> "lexforge"
@@ -67,6 +71,7 @@ tasks.register("writeCiBuildMatrix") {
             "supports_game_test_server" to supportsGameTestServer,
             "run_game_test_server" to (supportsGameTestServer && loader in setOf("forge", "neo")),
             "run_server" to !supportsGameTestServer,
+            "run_mc_runtime_test" to runMcRuntimeTest,
             "modloader" to modloader,
             "mc_runtime_test" to mcRuntimeTest,
             "artifact_regex" to ".*$loader.*",


### PR DESCRIPTION
## 概要

26.2 系のCIで `headlesshq/mc-runtime-test` が落ちるため、サブプロジェクトの `gradle.properties` からMC runtime testを切り捨てられるようにしました。

## 変更内容

- `writeCiBuildMatrix` が `ciMcRuntimeTest` を読み、未指定時は従来どおり有効にするよう変更
- CIのruntime JDK setup、mod staging、MC runtime test実行を `run_mc_runtime_test` 条件付きに変更
- `26.2-fabric` と `26.2-neo` に `ciMcRuntimeTest=false` を追加

## 影響

26.2 のbuild、artifact upload、Game Test / server smoke testは維持しつつ、MC runtime test clientだけをスキップします。他バージョンは未指定のため従来どおりruntime testを実行します。

## 確認

- `./gradlew --configuration-cache --no-daemon writeCiBuildMatrix`
- 生成された `build/ci/build-matrix.json` で `26.2-fabric` / `26.2-neo` の `run_mc_runtime_test=false` を確認
- `26.1.2-fabric` / `26.1.2-neo` は `run_mc_runtime_test=true` のまま確認