### PR TITLE
mdk(ci): enable 26.2 runtime tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Run MC runtime test client
         if: ${{ matrix.run_mc_runtime_test }}
         timeout-minutes: 10
-        uses: headlesshq/mc-runtime-test@4.4.0
+        uses: headlesshq/mc-runtime-test@4.5.0
         with:
           mc: ${{ matrix.minecraft }}
           modloader: ${{ matrix.modloader }}

--- a/26.2/fabric/gradle.properties
+++ b/26.2/fabric/gradle.properties
@@ -2,6 +2,5 @@ minecraftVersion=26.2
 fabricApiVersion=0.154.2+26.2
 javaVersion=25
 forgeConfigApiPortVersion=26.2.0
-ciMcRuntimeTest=false
 
 modmenuVersion=20.0.1

--- a/26.2/neo/gradle.properties
+++ b/26.2/neo/gradle.properties
@@ -3,4 +3,3 @@ minecraftVersionRange=[26.2]
 neoVersion=26.2.0.12-beta
 javaVersion=25
 neoDataRun=clientData
-ciMcRuntimeTest=false


### PR DESCRIPTION
## Summary

- update `headlesshq/mc-runtime-test` from 4.4.0 to 4.5.0
- re-enable the runtime test for the 26.2 Fabric and NeoForge projects

## Background

Minecraft 26.2 runtime tests were temporarily disabled because mc-runtime-test 4.4.0 crashed for that version. Version 4.5.0 includes the upstream fix, so the temporary project-level opt-outs can now be removed.

## Impact

CI will once again run the headless client runtime test for both `26.2-fabric` and `26.2-neo`.

## Validation

- `./gradlew --configuration-cache --no-daemon writeCiBuildMatrix`
- confirmed `run_mc_runtime_test: true` for both 26.2 targets in the generated matrix
- `git diff --check`

Closes #74