### PR TITLE
docs: improve template guidance for agents and contributors

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,18 @@
+# Agent Instructions
+
+Read the following documents before editing this repository:
+
+1. [`README.md`](README.md) for the template overview, setup, supported
+   platforms, and user-facing workflows.
+2. [`CONTRIBUTING.md`](CONTRIBUTING.md) for commit message conventions and
+   repository contribution rules.
+3. [`mdk/README.md`](mdk/README.md) for the agent-specific project map, edit
+   workflow, and verification guidance.
+
+Follow the instructions in those documents and keep them consistent with any
+related implementation changes. When instructions conflict, follow the most
+specific document for the files being changed.
+
+The `docs/` directory is maintained by the upstream `Meatwo310/custom-mdk`
+template. Downstream projects should avoid editing files in this directory,
+because those changes can conflict when updates from the template are merged.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing
 
+If you are working in `Meatwo310/custom-mdk` itself, follow
+[MDK Template Changes](#mdk-template-changes). Otherwise, follow
+[Commit Message Convention](#commit-message-convention).
+
 ## Commit Message Convention
 
 Commits should follow [Conventional Commits](https://www.conventionalcommits.org/):
@@ -10,7 +14,7 @@ type(scope): description
 
 Use the smallest scope that describes the affected area.
 
-## Scope Rules
+### Scope Rules
 
 Subprojects are named for shared code, Minecraft versions, and loader targets, such as `common`, `1.20.1-common`, `1.20.1-fabric`, `1.20.1-forge`, or `26.1.2-neo`. Versioned subprojects live under directories such as `1.20.1/common`, `1.20.1/fabric`, `1.20.1/forge`, or `26.1.2/neo`.
 
@@ -23,7 +27,7 @@ Subprojects are named for shared code, Minecraft versions, and loader targets, s
 | All subprojects equally                      | Scope is optional                                                        |
 | Root-level repository metadata only          | Scope is optional                                                        |
 
-## Recommended Types
+### Recommended Types
 
 `feat` / `fix` / `docs` / `style` / `refactor` / `perf` / `test` / `build` / `ci` / `chore` / `revert` / `release`
 
@@ -34,7 +38,7 @@ from release notes.
 Because these entries can appear in changelogs as written, prefer English for
 commit messages that may be included in release notes.
 
-## Examples
+### Examples
 
 ```
 feat(26.1.2-fabric): add config screen support

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ A Minecraft mod template for multi-version and multi-loader development, powered
 
 🌟 Primary support | ✅ Supported | 🚧 Partial support | ⏳ Planned | ❌ Not supported yet | 🚫 Unsupported
 
-Only the subprojects included in `settings.gradle.kts` are configured. Remove unused `include(...)` lines when you do not need a version or loader.
+Only the subprojects included in `settings.gradle.kts` are configured. Comment out unused `include(...)` lines when you do not need a version or loader.
 
 LLM agents and automation should also read [MDK Agent Notes](mdk/README.md) before editing this template.
 
@@ -38,12 +38,12 @@ LLM agents and automation should also read [MDK Agent Notes](mdk/README.md) befo
 
 ## Setup
 
-Before opening or importing the project in IntelliJ IDEA or Gradle, trim `settings.gradle.kts`: each included project adds Gradle configuration and IDE import load time. Comment out or remove any unused `include(...)` lines first.
+Before opening or importing the project in IntelliJ IDEA or Gradle, trim `settings.gradle.kts`: each included project adds Gradle configuration and IDE import load time. Comment out any unused `include(...)` lines first.
 
 1. Click **Use this template** on GitHub to create your repository from this template.
 2. If you want to keep receiving template updates, follow
    [Receiving Upstream Updates](#receiving-upstream-updates) before regular development.
-3. Edit `settings.gradle.kts` and remove unused subprojects to reduce Gradle configuration time and cache usage.
+3. Edit `settings.gradle.kts` and comment out unused subprojects to reduce Gradle configuration time and cache usage.
 4. Edit `gradle.properties` for your mod id, name, group, license, authors, URLs, and Fabric entry points, and edit `version.txt` for your mod version.
 5. Rename ALL Java package names (including those in the shared configuration system) to avoid conflicts with other mods. Update `Constants`, entry points, mixin config names, and language assets from `examplemod` to your mod id.
 6. Create a root `README.md` and `LICENSE` for your mod. Keep `docs/*.md` unchanged if you want future template updates to merge cleanly.
@@ -452,8 +452,8 @@ files:
 - Replace any newly introduced `net.meatwo310.examplemod` package names with
   your mod's namespace.
 - Newly added subprojects are enabled by default when their `include(...)` lines
-  are merged into `settings.gradle.kts`. Remove or comment out projects you do
-  not need before importing, building, or running CI.
+  are merged into `settings.gradle.kts`. Comment out projects you do not need
+  before importing, building, or running CI.
 
 ## Template License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ Before opening or importing the project in IntelliJ IDEA or Gradle, trim `settin
 1. Click **Use this template** on GitHub to create your repository from this template.
 2. If you want to keep receiving template updates, follow
    [Receiving Upstream Updates](#receiving-upstream-updates) before regular development.
-3. Edit `settings.gradle.kts` and comment out unused subprojects to reduce Gradle configuration time and cache usage.
+3. Edit `settings.gradle.kts` and comment out unused `include(...)` lines to reduce Gradle configuration time and cache usage.
 4. Edit `gradle.properties` for your mod id, name, group, license, authors, URLs, and Fabric entry points, and edit `version.txt` for your mod version.
 5. Rename ALL Java package names (including those in the shared configuration system) to avoid conflicts with other mods. Update `Constants`, entry points, mixin config names, and language assets from `examplemod` to your mod id.
 6. Create a root `README.md` and `LICENSE` for your mod. Keep `docs/*.md` unchanged if you want future template updates to merge cleanly.
@@ -452,7 +452,7 @@ files:
 - Replace any newly introduced `net.meatwo310.examplemod` package names with
   your mod's namespace.
 - Newly added subprojects are enabled by default when their `include(...)` lines
-  are merged into `settings.gradle.kts`. Comment out projects you do not need
+  are merged into `settings.gradle.kts`. Comment out the `include(...)` lines for projects you do not need
   before importing, building, or running CI.
 
 ## Template License


### PR DESCRIPTION
## Summary

- document that unused Gradle subprojects should be commented out rather than removed
- add `docs/AGENTS.md` as an entry point to template, contribution, and agent guidance
- clarify that downstream projects should avoid editing upstream-managed `docs/`
- route contributors to the appropriate commit convention and correct the heading hierarchy

## Why

These changes make the template guidance easier for coding agents and contributors to discover and follow while reducing downstream merge conflicts during template updates.

## Impact

Documentation-only change. Build behavior and generated artifacts are unchanged.

## Validation

- `git diff --check main...HEAD`
- verified the branch is based on and targets `main`