### PR TITLE
mdk(ci): preserve Gradle caches and cancel stale PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
 
       - name: Build with Gradle
         run: chmod u+x ./gradlew && ./gradlew ":${{ matrix.subproject }}:build"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
       - 'docs/**'
       - '*.md'
 
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   detect:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- cancel superseded Build workflow runs for the same pull request
- keep the `detect` job as the Gradle cache writer on the default branch
- make all 19 matrix build jobs restore-only with `cache-read-only: true`
- preserve the existing build, game test, server, and runtime test coverage

## Investigation

Issue #86 was caused primarily by Gradle cache churn rather than by the individual subproject builds.

The Build workflow first configures every project in `detect`, then expands into 19 matrix jobs. On a cold run, `detect` took 17m52s. Its Gradle User Home cache was 2.88 GB, but each matrix job could then save another roughly 3–4 GB job-specific Gradle User Home entry. After only two matrix jobs saved their entries, the `detect` cache had already disappeared from the cache list. At the end of the baseline run, the cache usage snapshot was 61 entries and 36.80 GB.

The successful matrix jobs themselves had a median duration of 5m01s, including a median of 2m14s for `Build with Gradle`. This showed that the large regression came from repeatedly losing and regenerating the cache used by `detect`, not from a broad slowdown in the target builds.

The proposed cache change was tested in `Meatwo310/custom-mdk-playground` from an empty cache:

| Condition | `detect` | Workflow result | Cache state |
| --- | ---: | --- | --- |
| baseline, cold | 17m52s | 25m38s, one unrelated runtime failure | `detect` cache evicted; 61 entries / 36.80 GB snapshot |
| optimized, cold | 16m36s | 25m18s, success | expected cold-generation cost |
| optimized, warm | 1m44s | 18 matrix jobs completed before an unrelated runtime hang | 29 entries / 6.32 GB; one Gradle User Home entry |

The warm `detect` job restored the exact Gradle User Home key in about 17 seconds and completed its Gradle task in 1m09s. Cache usage fell by about 83% in the observed snapshots while retaining the expensive cache needed by the next run.

## Changes

### Preserve the useful Gradle cache

`detect` remains writable. Because matrix jobs depend on it, its post-job cache save completes before those jobs start. Matrix jobs can restore that cache, but `cache-read-only: true` prevents them from replacing it with 19 job-specific entries on default-branch and manual runs.

### Cancel stale pull request runs

The workflow concurrency group is scoped by pull request number or ref. A newer run for the same pull request cancels its superseded run, avoiding another 19-job matrix competing for runners and Actions usage.

This intentionally does not combine `push` and `pull_request` runs: those events use different groups. Non-PR runs, including `main` pushes and manual runs, are not cancelled in progress.

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/build.yml`
- `git diff --check`
- cold baseline: https://github.com/Meatwo310/custom-mdk-playground/actions/runs/29394469311
- optimized cold run: https://github.com/Meatwo310/custom-mdk-playground/actions/runs/29395935570
- optimized warm run: https://github.com/Meatwo310/custom-mdk-playground/actions/runs/29397334208

The optimized warm run's `1.20.1-forge` runtime test hit its known intermittent hang after the Gradle build succeeded. The other 18 matrix jobs completed, and normal and forced cancellation requests were submitted. The cache and `detect` measurements were complete before that hang.

Related to #86.
