### PR TITLE
mdk(1.18.2-fabric): remove Fabric API runtime test workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run MC runtime test client
         if: ${{ matrix.run_mc_runtime_test }}
         timeout-minutes: 10
-        uses: headlesshq/mc-runtime-test@4.5.0
+        uses: headlesshq/mc-runtime-test@4.5.1
         with:
           mc: ${{ matrix.minecraft }}
           modloader: ${{ matrix.modloader }}

--- a/1.18.2/fabric/build.gradle.kts
+++ b/1.18.2/fabric/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
     id("fabric-legacy-config-conventions")
 }
 
-val fabricApiVersion = project.property("fabricApiVersion").toString()
-
 // Mod Dependencies
 dependencies {
-    // Fabric Maven publishes this legacy release as a thin aggregator jar.
-    add("ciRuntimeMods", "maven.modrinth:fabric-api:$fabricApiVersion")
 }

--- a/1.18.2/fabric/gradle.properties
+++ b/1.18.2/fabric/gradle.properties
@@ -1,7 +1,5 @@
 minecraftVersion=1.18.2
 fabricApiVersion=0.77.0+1.18.2
-# The complete Fabric API distribution is staged through ciRuntimeMods instead.
-ciFabricApiVersion=none
 forgeConfigApiPortVersion=3.2.4
 javaVersion=17
 parchmentMinecraftVersion=1.18.2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,9 +38,6 @@ tasks.register("writeCiBuildMatrix") {
             ?.toString()
             ?.substringBefore("+")
             ?: "none"
-        val ciFabricApiVersion = targetProject.findProperty("ciFabricApiVersion")
-            ?.toString()
-            ?: fabricApiVersion
         val runMcRuntimeTest = targetProject.findProperty("ciMcRuntimeTest")
             ?.toString()
             ?.toBooleanStrictOrNull()
@@ -72,7 +69,7 @@ tasks.register("writeCiBuildMatrix") {
             "loader" to loader,
             "minecraft" to minecraftVersion,
             "java" to javaVersion,
-            "fabric_api" to ciFabricApiVersion,
+            "fabric_api" to fabricApiVersion,
             "supports_game_test_server" to supportsGameTestServer,
             "run_game_test_server" to (supportsGameTestServer && loader in setOf("forge", "neo")),
             "run_server" to !supportsGameTestServer,


### PR DESCRIPTION
## Summary

- update `headlesshq/mc-runtime-test` from 4.5.0 to 4.5.1
- remove the 1.18.2 Fabric-only `ciRuntimeMods` staging of the full Fabric API distribution
- remove the `ciFabricApiVersion` matrix override and use the normal Fabric API version again

## Why

mc-runtime-test 4.5.0 downloaded the thin Maven artifact for legacy Fabric API releases, so 1.18.2 needed to stage the complete distribution separately and disable the action's Fabric API download. Version 4.5.1 now downloads the official Fabric API release JAR, making that workaround unnecessary.

This restores the regular CI path: the matrix passes Fabric API `0.77.0` to mc-runtime-test, while `ciRuntimeMods` only stages dependencies owned by this project.

## Validation

- `./gradlew --configuration-cache --no-daemon writeCiBuildMatrix :1.18.2-fabric:build`
- confirmed the `1.18.2-fabric` matrix entry contains `fabric_api: 0.77.0`
- confirmed `1.18.2/fabric/build/ciRuntimeMods` contains Forge Config API Port only
- `git diff --check`

Closes #91