### PR TITLE
mdk(config): expand builder metadata and comment handling

### DIFF
--- a/1.18.2/fabric/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.18.2/fabric/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -58,6 +58,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/1.18.2/fabric/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.18.2/fabric/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,23 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/1.18.2/forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.18.2/forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -58,6 +58,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/1.18.2/forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.18.2/forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,23 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/1.19.2/fabric/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.19.2/fabric/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -58,6 +58,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/1.19.2/fabric/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.19.2/fabric/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,23 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/1.19.2/forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.19.2/forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -58,6 +58,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/1.19.2/forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.19.2/forge/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,23 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/1.20.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.20.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -58,6 +58,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/1.20.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.20.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,23 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/1.21.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.21.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -63,6 +63,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/1.21.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.21.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,28 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
+        public void gameRestart() {
+            builder.gameRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/1.21.11/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.21.11/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -63,6 +63,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/1.21.11/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.21.11/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,28 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
+        public void gameRestart() {
+            builder.gameRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/1.21.8/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.21.8/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -63,6 +63,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/1.21.8/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/1.21.8/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,28 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
+        public void gameRestart() {
+            builder.gameRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/26.1.2/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/26.1.2/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -63,6 +63,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/26.1.2/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/26.1.2/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,28 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
+        public void gameRestart() {
+            builder.gameRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/26.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/26.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -63,6 +63,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/26.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/26.1/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,28 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
+        public void gameRestart() {
+            builder.gameRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/26.2/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/26.2/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -63,6 +63,11 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void pop() {
+            builder.pop();
+        }
+
+        @Override
         public void pop(int count) {
             builder.pop(count);
         }

--- a/26.2/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
+++ b/26.2/common/src/config/java/net/meatwo310/examplemod/mdk/config/VersionedConfigSpec.java
@@ -43,13 +43,28 @@ public final class VersionedConfigSpec {
         }
 
         @Override
+        public void translation(String translationKey) {
+            builder.translation(translationKey);
+        }
+
+        @Override
+        public void worldRestart() {
+            builder.worldRestart();
+        }
+
+        @Override
+        public void gameRestart() {
+            builder.gameRestart();
+        }
+
+        @Override
         public void push(String key) {
             builder.push(key);
         }
 
         @Override
-        public void pop() {
-            builder.pop();
+        public void pop(int count) {
+            builder.pop(count);
         }
 
         @Override

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntries.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntries.java
@@ -14,7 +14,7 @@ public class ConfigEntries {
         var elements = new ArrayList<ConfigElement>(children.elements.size() + 2);
         elements.add(new ConfigInstruction.Push(key, comment));
         elements.addAll(children.elements);
-        elements.add(new ConfigInstruction.Pop(1));
+        elements.add(new ConfigInstruction.Pop());
         return new ConfigEntries(elements);
     }
 

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntries.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntries.java
@@ -14,7 +14,7 @@ public class ConfigEntries {
         var elements = new ArrayList<ConfigElement>(children.elements.size() + 2);
         elements.add(new ConfigInstruction.Push(key, comment));
         elements.addAll(children.elements);
-        elements.add(new ConfigInstruction.Pop());
+        elements.add(new ConfigInstruction.Pop(1));
         return new ConfigEntries(elements);
     }
 

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBinder.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBinder.java
@@ -80,6 +80,11 @@ public final class ConfigEntryBinder implements ConfigVisitor {
     }
 
     @Override
+    public void pop() {
+        adapter.pop();
+    }
+
+    @Override
     public void pop(int count) {
         adapter.pop(count);
     }
@@ -100,6 +105,8 @@ public final class ConfigEntryBinder implements ConfigVisitor {
         default void gameRestart() {}
 
         void push(String key);
+
+        void pop();
 
         void pop(int count);
 

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBinder.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBinder.java
@@ -59,14 +59,29 @@ public final class ConfigEntryBinder implements ConfigVisitor {
     }
 
     @Override
+    public void translation(String translationKey) {
+        adapter.translation(translationKey);
+    }
+
+    @Override
+    public void worldRestart() {
+        adapter.worldRestart();
+    }
+
+    @Override
+    public void gameRestart() {
+        adapter.gameRestart();
+    }
+
+    @Override
     public void push(String key, String comment) {
         comment(comment);
         adapter.push(key);
     }
 
     @Override
-    public void pop() {
-        adapter.pop();
+    public void pop(int count) {
+        adapter.pop(count);
     }
 
     private void comment(String comment) {
@@ -78,9 +93,15 @@ public final class ConfigEntryBinder implements ConfigVisitor {
     public interface Adapter {
         void comment(String comment);
 
+        void translation(String translationKey);
+
+        void worldRestart();
+
+        default void gameRestart() {}
+
         void push(String key);
 
-        void pop();
+        void pop(int count);
 
         ConfigEntryBinding<Integer> defineIntInRange(String key, int defaultValue, int min, int max);
 

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBuilder.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBuilder.java
@@ -9,8 +9,14 @@ public class ConfigEntryBuilder {
     private final List<ConfigElement> elements = new ArrayList<>();
     private String pendingComment = "";
 
+    /**
+     * Appends a comment for the next entry or category. Consecutive comments are joined with newlines.
+     *
+     * @param comment the comment to append
+     * @return this builder
+     */
     public ConfigEntryBuilder comment(String comment) {
-        this.pendingComment = comment;
+        this.pendingComment = pendingComment.isEmpty() ? comment : pendingComment + "\n" + comment;
         return this;
     }
 

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBuilder.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBuilder.java
@@ -14,6 +14,38 @@ public class ConfigEntryBuilder {
         return this;
     }
 
+    /**
+     * Sets the exact translation key for the next entry or category.
+     *
+     * @param translationKey the translation key to use without deriving it from the category path
+     * @return this builder
+     */
+    public ConfigEntryBuilder translation(String translationKey) {
+        elements.add(new ConfigInstruction.Translation(translationKey));
+        return this;
+    }
+
+    /**
+     * Marks the next entry as requiring a world restart.
+     *
+     * @return this builder
+     */
+    public ConfigEntryBuilder worldRestart() {
+        elements.add(new ConfigInstruction.WorldRestart());
+        return this;
+    }
+
+    /**
+     * Marks the next entry as requiring a game restart. This setting is ignored on platforms that use the Forge Config
+     * API.
+     *
+     * @return this builder
+     */
+    public ConfigEntryBuilder gameRestart() {
+        elements.add(new ConfigInstruction.GameRestart());
+        return this;
+    }
+
     public ConfigEntry.IntEntry define(String key, int defaultValue) {
         return defineInRange(key, defaultValue, Integer.MIN_VALUE, Integer.MAX_VALUE);
     }
@@ -71,7 +103,17 @@ public class ConfigEntryBuilder {
     }
 
     public ConfigEntryBuilder pop() {
-        elements.add(new ConfigInstruction.Pop());
+        return pop(1);
+    }
+
+    /**
+     * Closes the requested number of sections.
+     *
+     * @param count the number of sections to close
+     * @return this builder
+     */
+    public ConfigEntryBuilder pop(int count) {
+        elements.add(new ConfigInstruction.Pop(count));
         return this;
     }
 

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBuilder.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigEntryBuilder.java
@@ -103,7 +103,8 @@ public class ConfigEntryBuilder {
     }
 
     public ConfigEntryBuilder pop() {
-        return pop(1);
+        elements.add(new ConfigInstruction.Pop());
+        return this;
     }
 
     /**
@@ -113,7 +114,7 @@ public class ConfigEntryBuilder {
      * @return this builder
      */
     public ConfigEntryBuilder pop(int count) {
-        elements.add(new ConfigInstruction.Pop(count));
+        elements.add(new ConfigInstruction.PopCount(count));
         return this;
     }
 

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigInstruction.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigInstruction.java
@@ -1,6 +1,33 @@
 package net.meatwo310.examplemod.mdk.config;
 
 public abstract class ConfigInstruction implements ConfigElement {
+    public static final class Translation extends ConfigInstruction {
+        private final String translationKey;
+
+        public Translation(String translationKey) {
+            this.translationKey = translationKey;
+        }
+
+        @Override
+        public void bindTo(ConfigVisitor visitor) {
+            visitor.translation(translationKey);
+        }
+    }
+
+    public static final class WorldRestart extends ConfigInstruction {
+        @Override
+        public void bindTo(ConfigVisitor visitor) {
+            visitor.worldRestart();
+        }
+    }
+
+    public static final class GameRestart extends ConfigInstruction {
+        @Override
+        public void bindTo(ConfigVisitor visitor) {
+            visitor.gameRestart();
+        }
+    }
+
     public static final class Push extends ConfigInstruction {
         private final String key;
         private final String comment;
@@ -25,9 +52,15 @@ public abstract class ConfigInstruction implements ConfigElement {
     }
 
     public static final class Pop extends ConfigInstruction {
+        private final int count;
+
+        public Pop(int count) {
+            this.count = count;
+        }
+
         @Override
         public void bindTo(ConfigVisitor visitor) {
-            visitor.pop();
+            visitor.pop(count);
         }
     }
 }

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigInstruction.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigInstruction.java
@@ -52,9 +52,16 @@ public abstract class ConfigInstruction implements ConfigElement {
     }
 
     public static final class Pop extends ConfigInstruction {
+        @Override
+        public void bindTo(ConfigVisitor visitor) {
+            visitor.pop();
+        }
+    }
+
+    public static final class PopCount extends ConfigInstruction {
         private final int count;
 
-        public Pop(int count) {
+        public PopCount(int count) {
             this.count = count;
         }
 

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigVisitor.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigVisitor.java
@@ -1,9 +1,15 @@
 package net.meatwo310.examplemod.mdk.config;
 
 public interface ConfigVisitor {
+    void translation(String translationKey);
+
+    void worldRestart();
+
+    void gameRestart();
+
     void push(String key, String comment);
 
-    void pop();
+    void pop(int count);
 
     void bind(ConfigEntry.IntEntry entry);
 

--- a/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigVisitor.java
+++ b/common/src/config/java/net/meatwo310/examplemod/mdk/config/ConfigVisitor.java
@@ -9,6 +9,8 @@ public interface ConfigVisitor {
 
     void push(String key, String comment);
 
+    void pop();
+
     void pop(int count);
 
     void bind(ConfigEntry.IntEntry entry);

--- a/docs/README.md
+++ b/docs/README.md
@@ -241,13 +241,14 @@ These conventions wire the `config` and `configClient` outputs into the jar and 
 Fabric 1.18.2-1.19.2 uses the archived `net.minecraftforge:forgeconfigapiport-fabric` artifact, which has no separate common artifact. Keep `VersionedConfigSpec` and other Forge Config API Port bindings in the Fabric project's `src/config`; `fabric-legacy-config-conventions` consumes the neutral declarations from root `common` and treats `<minecraft>/common/src/config` as optional. Do not apply it together with `fabric-config-conventions`.
 
 The builder supports primitive values, ranged numbers, strings, lists, enums,
-and nested sections. Use `translation(...)` to assign an exact translation key
-to the next entry or category regardless of its category path. Entries can be
-marked with `worldRestart()` on every platform or `gameRestart()` on NeoForge;
-platforms using the Forge Config API ignore `gameRestart()`. Prefer
-`category(...)` plus nested classes for hierarchical config; keep `push(...)`,
-`pop()`, and `pop(int count)` for low-level adapter work or unusual migration
-cases.
+and nested sections. Consecutive `comment(...)` calls are joined with newlines
+and applied to the next entry or category. Use `translation(...)` to assign an
+exact translation key to the next entry or category regardless of its category
+path. Entries can be marked with `worldRestart()` on every platform or
+`gameRestart()` on NeoForge; platforms using the Forge Config API ignore
+`gameRestart()`. Prefer `category(...)` plus nested classes for hierarchical
+config; keep `push(...)`, `pop()`, and `pop(int count)` for low-level adapter
+work or unusual migration cases.
 
 ```java
 package net.meatwo310.examplemod.config;

--- a/docs/README.md
+++ b/docs/README.md
@@ -240,7 +240,14 @@ These conventions wire the `config` and `configClient` outputs into the jar and 
 
 Fabric 1.18.2-1.19.2 uses the archived `net.minecraftforge:forgeconfigapiport-fabric` artifact, which has no separate common artifact. Keep `VersionedConfigSpec` and other Forge Config API Port bindings in the Fabric project's `src/config`; `fabric-legacy-config-conventions` consumes the neutral declarations from root `common` and treats `<minecraft>/common/src/config` as optional. Do not apply it together with `fabric-config-conventions`.
 
-The builder supports primitive values, ranged numbers, strings, lists, enums, and nested sections. Prefer `category(...)` plus nested classes for hierarchical config; keep `push(...)` and `pop()` for low-level adapter work or unusual migration cases.
+The builder supports primitive values, ranged numbers, strings, lists, enums,
+and nested sections. Use `translation(...)` to assign an exact translation key
+to the next entry or category regardless of its category path. Entries can be
+marked with `worldRestart()` on every platform or `gameRestart()` on NeoForge;
+platforms using the Forge Config API ignore `gameRestart()`. Prefer
+`category(...)` plus nested classes for hierarchical config; keep `push(...)`,
+`pop()`, and `pop(int count)` for low-level adapter work or unusual migration
+cases.
 
 ```java
 package net.meatwo310.examplemod.config;

--- a/docs/mdk/config-api.md
+++ b/docs/mdk/config-api.md
@@ -47,12 +47,18 @@ classes solely for style. They add noise and do not clarify the config API.
 - `comment(String comment)` stores a comment for the next entry or category.
   Blank comments are treated as absent during binding and must not be forwarded
   to loader-specific config builders.
+- `translation(String translationKey)` assigns the exact translation key to
+  the next entry or category without deriving it from the category path.
+- `worldRestart()` marks the next entry as requiring a world restart.
+- `gameRestart()` marks the next entry as requiring a game restart on
+  NeoForge. Platforms using the Forge Config API ignore it.
 - `define(...)` defines unrestricted primitive, boolean, or string values. Supported overloads are `int`, `long`, `double`, `boolean`, and `String`.
 - `defineInRange(...)` defines ranged numeric values. Supported overloads are `int`, `long`, and `double`.
 - `defineList(...)` defines a list from a default value, a new-element supplier for config screens, and an element validator.
 - `defineEnum(...)` defines an enum value from its default enum constant.
 - `category(String key, ConfigEntries children)` appends a nested section and should be preferred for hierarchy.
-- `push(String key)` and `pop()` manually open and close sections. Treat them as low-level API.
+- `push(String key)`, `pop()`, and `pop(int count)` manually open and close
+  sections. Treat them as low-level API.
 - `build()` returns the immutable `ConfigEntries` for the class or category.
 
 `ConfigEntries` is normally produced by `build()` or `category(...)`:

--- a/docs/mdk/config-api.md
+++ b/docs/mdk/config-api.md
@@ -44,9 +44,10 @@ classes solely for style. They add noise and do not clarify the config API.
 
 `ConfigEntryBuilder` is the normal entry-definition API:
 
-- `comment(String comment)` stores a comment for the next entry or category.
-  Blank comments are treated as absent during binding and must not be forwarded
-  to loader-specific config builders.
+- `comment(String comment)` appends a comment for the next entry or category.
+  Consecutive calls are joined with newlines in declaration order. Blank
+  comments are treated as absent during binding and must not be forwarded to
+  loader-specific config builders.
 - `translation(String translationKey)` assigns the exact translation key to
   the next entry or category without deriving it from the category path.
 - `worldRestart()` marks the next entry as requiring a world restart.


### PR DESCRIPTION
## Summary

- add `translation(String)`, `worldRestart()`, `gameRestart()`, and `pop(int count)` to the shared `ConfigEntryBuilder` while preserving the existing `pop()` API path
- join consecutive `comment(...)` calls with newlines and apply the combined string to the next entry or category
- forward exact translation keys and restart metadata through every versioned config adapter
- treat `gameRestart()` as a no-op on Forge Config API platforms while forwarding it to NeoForge
- document the new API and platform behavior

## Why

The shared config declaration API could not express metadata and section operations already available from the native config builders. It also replaced earlier comments when `comment(...)` was called repeatedly, leaving only the final string.

`translation(String)` is forwarded verbatim, so category paths do not alter the explicitly supplied key. Repeated comments are retained in declaration order as one newline-delimited string.

## Impact

Template users can keep these declarations in shared config code and build multi-line comments incrementally. Forge and Forge Config API Port continue to ignore game-restart metadata because their builder API does not expose it; the public JavaDoc calls this out.

## Validation

- compiled every shared/versioned config adapter from 1.18.2 through 26.2
- built representative 1.18.2 Forge, 1.20.1 Fabric, and 26.1 NeoForge projects
- verified consecutive comments produce `first\nsecond` and reset after entry registration
- `git diff --check`